### PR TITLE
[Infra][DB] Integrate tRPC and Prisma

### DIFF
--- a/example.env
+++ b/example.env
@@ -1,0 +1,1 @@
+# DATABASE_URL="postgresql://username:password@host:port/dbname?schema=public"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,16 +14,26 @@
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@next/third-parties": "^15.3.1",
+        "@tanstack/react-query": "^5.80.2",
+        "@trpc/client": "^11.2.0",
+        "@trpc/next": "^11.2.0",
+        "@trpc/react-query": "^11.2.0",
+        "@trpc/server": "^11.2.0",
+        "client-only": "^0.0.1",
         "dayjs": "^1.11.13",
         "lucide-react": "^0.503.0",
         "next": "^15.3.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "tailwindcss-animate": "^1.0.7"
+        "server-only": "^0.0.1",
+        "tailwindcss-animate": "^1.0.7",
+        "zod": "^3.25.49"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4",
+        "@types/node": "22.15.29",
+        "@types/react": "19.1.6",
         "eslint": "^9",
         "eslint-config-next": "15.3.1",
         "tailwindcss": "^4"
@@ -1241,6 +1251,101 @@
         "tailwindcss": "4.1.4"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.80.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.80.2.tgz",
+      "integrity": "sha512-g2Es97uwFk7omkWiH9JmtLWSA8lTUFVseIyzqbjqJEEx7qN+Hg6jbBdDvelqtakamppaJtGORQ64hEJ5S6ojSg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.80.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.80.2.tgz",
+      "integrity": "sha512-LfA0SVheJBOqC8RfJw/JbOW3yh2zuONQeWU5Prjm7yjUGUONeOedky1Bj39Cfj8MRdXrZV+DxNT7/DN/M907lQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.80.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@trpc/client": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@trpc/client/-/client-11.2.0.tgz",
+      "integrity": "sha512-uGehc0QvK3+UmTZb1KmIwvMLtRW0I5ykiYQHA1Yqa7yHPzpF9zw7mbwna6gqZAgjclt0/S6jwxAMJizoaP8uqQ==",
+      "funding": [
+        "https://trpc.io/sponsor"
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@trpc/server": "11.2.0",
+        "typescript": ">=5.7.2"
+      }
+    },
+    "node_modules/@trpc/next": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@trpc/next/-/next-11.2.0.tgz",
+      "integrity": "sha512-PyTe8GXn14NaTnHqm7ggR9PtgQhBUiW+3HPVIvwTy9/P9P4xw+A4Kl6V8BZV4Sq4jkmapuEY2rLquVtV3nhYzw==",
+      "funding": [
+        "https://trpc.io/sponsor"
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.59.15",
+        "@trpc/client": "11.2.0",
+        "@trpc/react-query": "11.2.0",
+        "@trpc/server": "11.2.0",
+        "next": "*",
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0",
+        "typescript": ">=5.7.2"
+      },
+      "peerDependenciesMeta": {
+        "@tanstack/react-query": {
+          "optional": true
+        },
+        "@trpc/react-query": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@trpc/react-query": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@trpc/react-query/-/react-query-11.2.0.tgz",
+      "integrity": "sha512-eVbvjUzvia7B+Xt3002YRlU2/u+jljtVdOTErT6ffMHC2T5ETop84oyqnsmXpMlnhT5y/We6v/KGpE4GUE2Zkw==",
+      "funding": [
+        "https://trpc.io/sponsor"
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.67.1",
+        "@trpc/client": "11.2.0",
+        "@trpc/server": "11.2.0",
+        "react": ">=18.2.0",
+        "react-dom": ">=18.2.0",
+        "typescript": ">=5.7.2"
+      }
+    },
+    "node_modules/@trpc/server": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-11.2.0.tgz",
+      "integrity": "sha512-clESXvCT3rTRUavB3wjtmPDlbB+rayVPeaTeXEQVeQNdTrK5o6GnYfCdiJJSdQspUQAwkGgQFRnku5pckuISlw==",
+      "funding": [
+        "https://trpc.io/sponsor"
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5.7.2"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
@@ -1272,6 +1377,26 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.15.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.29.tgz",
+      "integrity": "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.1.6",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.6.tgz",
+      "integrity": "sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.31.0",
@@ -2231,6 +2356,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -5081,6 +5213,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -5705,7 +5843,6 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -5734,6 +5871,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unrs-resolver": {
       "version": "1.6.3",
@@ -5903,6 +6047,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.49",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.49.tgz",
+      "integrity": "sha512-JMMPMy9ZBk3XFEdbM3iL1brx4NUSejd6xr3ELrrGEfGb355gjhiAWtG3K5o+AViV/3ZfkIrCzXsZn6SbLwTR8Q==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@next/third-parties": "^15.3.1",
+        "@prisma/client": "^6.9.0",
         "@tanstack/react-query": "^5.80.2",
         "@trpc/client": "^11.2.0",
         "@trpc/next": "^11.2.0",
@@ -36,6 +37,7 @@
         "@types/react": "19.1.6",
         "eslint": "^9",
         "eslint-config-next": "15.3.1",
+        "prisma": "^6.9.0",
         "tailwindcss": "^4"
       }
     },
@@ -952,6 +954,88 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@prisma/client": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.9.0.tgz",
+      "integrity": "sha512-Gg7j1hwy3SgF1KHrh0PZsYvAaykeR0PaxusnLXydehS96voYCGt1U5zVR31NIouYc63hWzidcrir1a7AIyCsNQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "prisma": "*",
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/config": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.9.0.tgz",
+      "integrity": "sha512-Wcfk8/lN3WRJd5w4jmNQkUwhUw0eksaU/+BlAJwPQKW10k0h0LC9PD/6TQFmqKVbHQL0vG2z266r0S1MPzzhbA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jiti": "2.4.2"
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.9.0.tgz",
+      "integrity": "sha512-bFeur/qi/Q+Mqk4JdQ3R38upSYPebv5aOyD1RKywVD+rAMLtRkmTFn28ZuTtVOnZHEdtxnNOCH+bPIeSGz1+Fg==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.9.0.tgz",
+      "integrity": "sha512-im0X0bwDLA0244CDf8fuvnLuCQcBBdAGgr+ByvGfQY9wWl6EA+kRGwVk8ZIpG65rnlOwtaWIr/ZcEU5pNVvq9g==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.9.0",
+        "@prisma/engines-version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
+        "@prisma/fetch-engine": "6.9.0",
+        "@prisma/get-platform": "6.9.0"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e.tgz",
+      "integrity": "sha512-Qp9gMoBHgqhKlrvumZWujmuD7q4DV/gooEyPCLtbkc13EZdSz2RsGUJ5mHb3RJgAbk+dm6XenqG7obJEhXcJ6Q==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.9.0.tgz",
+      "integrity": "sha512-PMKhJdl4fOdeE3J3NkcWZ+tf3W6rx3ht/rLU8w4SXFRcLhd5+3VcqY4Kslpdm8osca4ej3gTfB3+cSk5pGxgFg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.9.0",
+        "@prisma/engines-version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
+        "@prisma/get-platform": "6.9.0"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.9.0.tgz",
+      "integrity": "sha512-/B4n+5V1LI/1JQcHp+sUpyRT1bBgZVPHbsC4lt4/19Xp4jvNIVcq5KYNtQDk5e/ukTSjo9PZVAxxy9ieFtlpTQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.9.0"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -4063,7 +4147,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
       "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -4948,6 +5032,32 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prisma": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.9.0.tgz",
+      "integrity": "sha512-resJAwMyZREC/I40LF6FZ6rZTnlrlrYrb63oW37Gq+U+9xHwbyMSPJjKtM7VZf3gTO86t/Oyz+YeSXr3CmAY1Q==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/config": "6.9.0",
+        "@prisma/engines": "6.9.0"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/prop-types": {

--- a/package.json
+++ b/package.json
@@ -15,16 +15,26 @@
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@next/third-parties": "^15.3.1",
+    "@tanstack/react-query": "^5.80.2",
+    "@trpc/client": "^11.2.0",
+    "@trpc/next": "^11.2.0",
+    "@trpc/react-query": "^11.2.0",
+    "@trpc/server": "^11.2.0",
+    "client-only": "^0.0.1",
     "dayjs": "^1.11.13",
     "lucide-react": "^0.503.0",
     "next": "^15.3.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "tailwindcss-animate": "^1.0.7"
+    "server-only": "^0.0.1",
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.25.49"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@types/node": "22.15.29",
+    "@types/react": "19.1.6",
     "eslint": "^9",
     "eslint-config-next": "15.3.1",
     "tailwindcss": "^4"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@next/third-parties": "^15.3.1",
+    "@prisma/client": "^6.9.0",
     "@tanstack/react-query": "^5.80.2",
     "@trpc/client": "^11.2.0",
     "@trpc/next": "^11.2.0",
@@ -37,6 +38,7 @@
     "@types/react": "19.1.6",
     "eslint": "^9",
     "eslint-config-next": "15.3.1",
+    "prisma": "^6.9.0",
     "tailwindcss": "^4"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,9 @@
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["driverAdapters"]
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}

--- a/src/app/(admin)/admin/client-greeting.tsx
+++ b/src/app/(admin)/admin/client-greeting.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { trpc } from "../../../trpc/client";
+
+export function ClientGreeting() {
+  const greeting = trpc.getHello.useQuery({
+    text: "brothers and sisters",
+  });
+  if (!greeting.data) return <>...</>;
+  return <>{greeting.data.greeting}</>;
+}

--- a/src/app/(admin)/admin/layout.js
+++ b/src/app/(admin)/admin/layout.js
@@ -1,9 +1,0 @@
-export default function RootLayout({ children }) {
-  return (
-    <html lang="en">
-      <body>
-        {children}
-      </body>
-    </html>
-  );
-}

--- a/src/app/(admin)/admin/layout.tsx
+++ b/src/app/(admin)/admin/layout.tsx
@@ -1,0 +1,13 @@
+import { TRPCProvider } from "../../../trpc/client";
+
+export default function RootLayout({ children }: any) {
+  return (
+    <TRPCProvider>
+      <html lang="en">
+        <body>
+          {children}
+        </body>
+      </html>
+    </TRPCProvider>
+  );
+}

--- a/src/app/(admin)/admin/page.jsx
+++ b/src/app/(admin)/admin/page.jsx
@@ -1,5 +1,0 @@
-export default function AdminHomePage() {
-  return (
-    <p>Hello from Admin page!</p>
-  );
-}

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -1,9 +1,9 @@
 import { HydrateClient, trpc } from "../../../trpc/server";
 import { ClientGreeting } from "./client-greeting";
 
-export default function AdminHomePage() {
+export default async function AdminHomePage() {
   // This is for server-side rendering (on first page load)
-  void trpc.getHello.prefetch({
+  await trpc.getHello.prefetch({
     text: "brothers and sisters",
   });
 

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -1,0 +1,15 @@
+import { HydrateClient, trpc } from "../../../trpc/server";
+import { ClientGreeting } from "./client-greeting";
+
+export default function AdminHomePage() {
+  // This is for server-side rendering (on first page load)
+  void trpc.getHello.prefetch({
+    text: "brothers and sisters",
+  });
+
+  return (
+    <HydrateClient>
+      <p><ClientGreeting /> Welcome to Admin page!</p>
+    </HydrateClient>
+  );
+}

--- a/src/app/(api)/api/trpc/[trpc]/route.ts
+++ b/src/app/(api)/api/trpc/[trpc]/route.ts
@@ -1,0 +1,35 @@
+import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
+import { appRouter } from '../../../../../trpc/routers/_app';
+import { NextRequest, NextResponse } from 'next/server';
+
+// Separate function for OPTIONS method (first connect from client)
+export async function OPTIONS(req: NextRequest) {
+  return new NextResponse(null, {
+    status: 204, // No Content
+    headers: {
+      // TODO: Change to frontend domains automatically
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'OPTIONS, GET, POST',
+      'Access-Control-Allow-Headers': 'Content-Type',
+    },
+  });
+}
+
+const handler = (req: Request) => {
+  return fetchRequestHandler({
+    endpoint: '/trpc',
+    req,
+    router: appRouter,
+    createContext: () => ({}),
+    responseMeta({ }) {
+      return {
+        headers: {
+          // TODO: Change to frontend domains automatically
+          'Access-Control-Allow-Origin': '*',
+        },
+      };
+    },
+  });
+};
+
+export { handler as GET, handler as POST };

--- a/src/app/(api)/api/trpc/[trpc]/route.ts
+++ b/src/app/(api)/api/trpc/[trpc]/route.ts
@@ -1,6 +1,7 @@
 import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
-import { appRouter } from '../../../../../trpc/routers/_app';
 import { NextRequest, NextResponse } from 'next/server';
+import { createTRPCContext } from '../../../../../trpc/init';
+import { appRouter } from '../../../../../trpc/routers/_app';
 
 // Separate function for OPTIONS method (first connect from client)
 export async function OPTIONS(req: NextRequest) {
@@ -20,7 +21,7 @@ const handler = (req: Request) => {
     endpoint: '/trpc',
     req,
     router: appRouter,
-    createContext: () => ({}),
+    createContext: createTRPCContext,
     responseMeta({ }) {
       return {
         headers: {

--- a/src/trpc/client.tsx
+++ b/src/trpc/client.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import type { QueryClient } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { httpBatchLink } from '@trpc/client';
+import { createTRPCReact } from '@trpc/react-query';
+import { useState } from 'react';
+import { makeQueryClient } from './query-client';
+import type { AppRouter } from './routers/_app';
+
+export const trpc = createTRPCReact<AppRouter>();
+
+let clientQueryClientSingleton: QueryClient;
+function getQueryClient() {
+  if (typeof window === 'undefined') {
+    // Server: always make a new query client
+    return makeQueryClient();
+  }
+  // Browser: use singleton pattern to keep the same query client
+  return (clientQueryClientSingleton ??= makeQueryClient());
+}
+
+function getUrl() {
+  const base = (() => {
+    // TODO: Adapt for local and development environment
+    // if (typeof window !== 'undefined') return '';
+    if (process.env.VERCEL_URL) return `https://api.${process.env.VERCEL_URL}`;
+    return 'http://api.localhost:3000';
+  })();
+  return `${base}/trpc`;
+}
+
+export function TRPCProvider(
+  props: Readonly<{
+    children: React.ReactNode;
+  }>,
+) {
+  const queryClient = getQueryClient();
+  const [trpcClient] = useState(() =>
+    trpc.createClient({
+      links: [
+        httpBatchLink({
+          url: getUrl(),
+        }),
+      ],
+    }),
+  );
+  return (
+    <trpc.Provider client={trpcClient} queryClient={queryClient}>
+      <QueryClientProvider client={queryClient}>
+        {props.children}
+      </QueryClientProvider>
+    </trpc.Provider>
+  );
+}

--- a/src/trpc/init.ts
+++ b/src/trpc/init.ts
@@ -1,0 +1,7 @@
+import { initTRPC } from '@trpc/server';
+
+const t = initTRPC.create();
+
+export const createTRPCRouter = t.router;
+export const createCallerFactory = t.createCallerFactory;
+export const baseProcedure = t.procedure;

--- a/src/trpc/init.ts
+++ b/src/trpc/init.ts
@@ -1,6 +1,16 @@
+import { PrismaClient } from '@prisma/client';
 import { initTRPC } from '@trpc/server';
+import { cache } from 'react';
 
-const t = initTRPC.create();
+const prisma = new PrismaClient();
+
+export const createTRPCContext = cache(async () => {
+  return { prisma }
+});
+
+export type TRPCContext = Awaited<ReturnType<typeof createTRPCContext>>;
+
+const t = initTRPC.context<TRPCContext>().create();
 
 export const createTRPCRouter = t.router;
 export const createCallerFactory = t.createCallerFactory;

--- a/src/trpc/query-client.ts
+++ b/src/trpc/query-client.ts
@@ -1,0 +1,18 @@
+import { defaultShouldDehydrateQuery, QueryClient } from '@tanstack/react-query';
+
+export function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 30 * 1000,
+      },
+      dehydrate: {
+        shouldDehydrateQuery: (query) =>
+          defaultShouldDehydrateQuery(query) ||
+          query.state.status === 'pending',
+      },
+      hydrate: {
+      },
+    },
+  });
+}

--- a/src/trpc/routers/_app.ts
+++ b/src/trpc/routers/_app.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+import { baseProcedure, createTRPCRouter } from '../init';
+
+export const appRouter = createTRPCRouter({
+  getHello: baseProcedure
+    .input(
+      z.object({
+        text: z.string(),
+      }),
+    )
+    .query((opts) => {
+      return {
+        greeting: `Hello, ${opts.input.text}!`,
+      };
+    }),
+});
+
+export type AppRouter = typeof appRouter;

--- a/src/trpc/routers/_app.ts
+++ b/src/trpc/routers/_app.ts
@@ -8,9 +8,17 @@ export const appRouter = createTRPCRouter({
         text: z.string(),
       }),
     )
-    .query((opts) => {
+    .query(async (opts) => {
+      const helloString = `Hello, ${opts.input.text}!`
+      const result = await opts.ctx.prisma.$queryRaw<{hello: string}[]>`SELECT ${helloString} AS hello`;
+
+      let greeting: string = `${helloString} (cannot get data from database)`;
+      if (result.length > 0) {
+        greeting = result[0]["hello"];
+      }
+
       return {
-        greeting: `Hello, ${opts.input.text}!`,
+        greeting,
       };
     }),
 });

--- a/src/trpc/server.tsx
+++ b/src/trpc/server.tsx
@@ -1,0 +1,15 @@
+import 'server-only';
+
+import { createHydrationHelpers } from '@trpc/react-query/rsc';
+import { cache } from 'react';
+import { createCallerFactory } from './init';
+import { makeQueryClient } from './query-client';
+import { appRouter } from './routers/_app';
+
+export const getQueryClient = cache(makeQueryClient);
+const caller = createCallerFactory(appRouter)(() => ({}));
+
+export const { trpc, HydrateClient } = createHydrationHelpers<typeof appRouter>(
+  caller,
+  getQueryClient,
+);

--- a/src/trpc/server.tsx
+++ b/src/trpc/server.tsx
@@ -2,12 +2,12 @@ import 'server-only';
 
 import { createHydrationHelpers } from '@trpc/react-query/rsc';
 import { cache } from 'react';
-import { createCallerFactory } from './init';
+import { createCallerFactory, createTRPCContext } from './init';
 import { makeQueryClient } from './query-client';
 import { appRouter } from './routers/_app';
 
 export const getQueryClient = cache(makeQueryClient);
-const caller = createCallerFactory(appRouter)(() => ({}));
+const caller = createCallerFactory(appRouter)(createTRPCContext);
 
 export const { trpc, HydrateClient } = createHydrationHelpers<typeof appRouter>(
   caller,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": [
+      "dom",
+      "dom.iterable"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "incremental": true,
+    "module": "nodenext",
+    "esModuleInterop": true,
+    "moduleResolution": "nodenext",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    ".next/types/**/*.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
Basic tRPC example is added.
Basic Prisma client is added into the tRPC context.

### To do:
Automatic detection between dev vs. prod to
- allow setting CORS's origin (`Access-Control-Allow-Origin`) to be only frontend domains
- set tRPC's base URL

Related: SVP-24 SVP-25