### PR TITLE
[DB] Change industries and entrepreneur stage to be tables

### DIFF
--- a/docs/db/sevenpreneur-ddl.sql
+++ b/docs/db/sevenpreneur-ddl.sql
@@ -1,85 +1,54 @@
 -- PostgreSQL Database for Sevenpreneur
--- USE sevenpreneur;
 
 ------------------
 -- Enumerations --
 ------------------
-
--- Enumeration for the users table (currently)
 
 CREATE TYPE status_enum AS ENUM (
   'active',
   'inactive'
 );
 
--- Enumeration for the users table (u_*)
-
-CREATE TYPE u_stage_enum AS ENUM (
-  'ideation',
-  'feasibility_analysis',
-  'business_planning',
-  'execution',
-  'growth'
-);
-
-CREATE TYPE u_industry_enum AS ENUM (
-  'agriculture',
-  'automotive',
-  'biotechnology',
-  'chemicals',
-  'construction',
-  'consulting',
-  'consumer_goods',
-  'education',
-  'energy',
-  'engineering',
-  'entertainment',
-  'environmental_services',
-  'fashion',
-  'financial_services',
-  'food_and_beverage',
-  'government',
-  'healthcare',
-  'hospitality',
-  'human_resources',
-  'information_technology',
-  'insurance',
-  'legal',
-  'logistics_and_transportation',
-  'manufacturing',
-  'media',
-  'mining',
-  'non_profit',
-  'pharmaceuticals',
-  'public_relations',
-  'real_estate',
-  'retail',
-  'telecommunications',
-  'textiles',
-  'tourism',
-  'utilities'
-);
-
 ------------
 -- Tables --
 ------------
 
+CREATE TABLE industries (
+  id             SMALLSERIAL  PRIMARY KEY,
+  industry_name  VARCHAR      NOT NULL  UNIQUE,
+  created_at     TIMESTAMPTZ  NOT NULL  DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE entrepreneur_stages (
+  id          SMALLSERIAL  PRIMARY KEY,
+  stage_name  VARCHAR      NOT NULL  UNIQUE,
+  created_at  TIMESTAMPTZ  NOT NULL  DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE roles (
+  id          SMALLSERIAL  PRIMARY KEY,
+  name        VARCHAR      NOT NULL  UNIQUE,
+  permission  SMALLINT     NOT NULL,
+  created_at  TIMESTAMPTZ  NOT NULL  DEFAULT CURRENT_TIMESTAMP,
+  updated_at  TIMESTAMPTZ  NOT NULL  DEFAULT CURRENT_TIMESTAMP
+);
+
 CREATE TABLE users (
-  id                  UUID             PRIMARY KEY  DEFAULT gen_random_uuid(),
-  full_name           VARCHAR          NOT NULL,
-  email               VARCHAR          NOT NULL     UNIQUE,
-  avatar              VARCHAR              NULL,
-  role_id             SMALLINT         NOT NULL,
-  status              status_enum      NOT NULL,
-  date_of_birth       DATE             NOT NULL,
-  learning_goal       VARCHAR          NOT NULL,
-  entrepreneur_stage  u_stage_enum         NULL,
-  business_name       VARCHAR              NULL,
-  industry            u_industry_enum  NOT NULL,
-  created_at          TIMESTAMPTZ      NOT NULL     DEFAULT CURRENT_TIMESTAMP,
-  updated_at          TIMESTAMPTZ      NOT NULL     DEFAULT CURRENT_TIMESTAMP,
-  last_login          TIMESTAMPTZ      NOT NULL     DEFAULT CURRENT_TIMESTAMP,
-  deleted_at          TIMESTAMPTZ          NULL
+  id                  UUID         PRIMARY KEY  DEFAULT gen_random_uuid(),
+  full_name           VARCHAR      NOT NULL,
+  email               VARCHAR      NOT NULL     UNIQUE,
+  avatar              VARCHAR          NULL,
+  role_id             SMALLINT     NOT NULL     DEFAULT 3, -- General User
+  status              status_enum  NOT NULL     DEFAULT 'active',
+  date_of_birth       DATE             NULL,
+  learning_goal       VARCHAR          NULL,
+  entrepreneur_stage  SMALLINT         NULL,
+  business_name       VARCHAR          NULL,
+  industry_id         SMALLINT         NULL,
+  created_at          TIMESTAMPTZ  NOT NULL     DEFAULT CURRENT_TIMESTAMP,
+  updated_at          TIMESTAMPTZ  NOT NULL     DEFAULT CURRENT_TIMESTAMP,
+  last_login          TIMESTAMPTZ  NOT NULL     DEFAULT CURRENT_TIMESTAMP,
+  deleted_at          TIMESTAMPTZ      NULL
 );
 
 CREATE TABLE tokens (
@@ -88,12 +57,4 @@ CREATE TABLE tokens (
   is_active   BOOLEAN      NOT NULL  DEFAULT FALSE,
   token       TEXT         NOT NULL  UNIQUE,
   created_at  TIMESTAMPTZ  NOT NULL  DEFAULT CURRENT_TIMESTAMP
-);
-
-CREATE TABLE roles (
-  id          SMALLSERIAL  PRIMARY KEY,
-  name        VARCHAR      NOT NULL,
-  permission  SMALLINT     NOT NULL,
-  created_at  TIMESTAMPTZ  NOT NULL  DEFAULT CURRENT_TIMESTAMP,
-  updated_at  TIMESTAMPTZ  NOT NULL  DEFAULT CURRENT_TIMESTAMP
 );

--- a/docs/db/sevenpreneur-dml.sql
+++ b/docs/db/sevenpreneur-dml.sql
@@ -1,11 +1,62 @@
 -- PostgreSQL Database for Sevenpreneur
--- USE sevenpreneur;
 
 ---------------
 -- Time Zone --
 ---------------
 
 SET TIMEZONE = 'Asia/Jakarta'; -- For these queries in this transaction
+
+----------------
+-- Industries --
+----------------
+
+INSERT INTO industries (industry_name, created_at) VALUES
+  ('Agriculture',                  '2025-05-27 09:00:00+07:00'),
+  ('Automotive',                   '2025-05-27 09:00:00+07:00'),
+  ('Biotechnology',                '2025-05-27 09:00:00+07:00'),
+  ('Chemicals',                    '2025-05-27 09:00:00+07:00'),
+  ('Construction',                 '2025-05-27 09:00:00+07:00'),
+  ('Consulting',                   '2025-05-27 09:00:00+07:00'),
+  ('Consumer Goods',               '2025-05-27 09:00:00+07:00'),
+  ('Education',                    '2025-05-27 09:00:00+07:00'),
+  ('Energy',                       '2025-05-27 09:00:00+07:00'),
+  ('Engineering',                  '2025-05-27 09:00:00+07:00'),
+  ('Entertainment',                '2025-05-27 09:00:00+07:00'),
+  ('Environmental Services',       '2025-05-27 09:00:00+07:00'),
+  ('Fashion',                      '2025-05-27 09:00:00+07:00'),
+  ('Financial Services',           '2025-05-27 09:00:00+07:00'),
+  ('Food and Beverage',            '2025-05-27 09:00:00+07:00'),
+  ('Government',                   '2025-05-27 09:00:00+07:00'),
+  ('Healthcare',                   '2025-05-27 09:00:00+07:00'),
+  ('Hospitality',                  '2025-05-27 09:00:00+07:00'),
+  ('Human Resources',              '2025-05-27 09:00:00+07:00'),
+  ('Information Technology',       '2025-05-27 09:00:00+07:00'),
+  ('Insurance',                    '2025-05-27 09:00:00+07:00'),
+  ('Legal',                        '2025-05-27 09:00:00+07:00'),
+  ('Logistics and Transportation', '2025-05-27 09:00:00+07:00'),
+  ('Manufacturing',                '2025-05-27 09:00:00+07:00'),
+  ('Media',                        '2025-05-27 09:00:00+07:00'),
+  ('Mining',                       '2025-05-27 09:00:00+07:00'),
+  ('Non Profit',                   '2025-05-27 09:00:00+07:00'),
+  ('Pharmaceuticals',              '2025-05-27 09:00:00+07:00'),
+  ('Public Relations',             '2025-05-27 09:00:00+07:00'),
+  ('Real Estate',                  '2025-05-27 09:00:00+07:00'),
+  ('Retail',                       '2025-05-27 09:00:00+07:00'),
+  ('Telecommunications',           '2025-05-27 09:00:00+07:00'),
+  ('Textiles',                     '2025-05-27 09:00:00+07:00'),
+  ('Tourism',                      '2025-05-27 09:00:00+07:00'),
+  ('Utilities',                    '2025-05-27 09:00:00+07:00');
+
+------------------------
+-- Entrepreneur Stage --
+------------------------
+
+INSERT INTO entrepreneur_stages (stage_name, created_at) VALUES
+  ('Ideation',             '2025-05-27 09:00:00+07:00'),
+  ('Feasibility Analysis', '2025-05-27 09:00:00+07:00'),
+  ('Business Planning',    '2025-05-27 09:00:00+07:00'),
+  ('Execution',            '2025-05-27 09:00:00+07:00'),
+  ('Growth',               '2025-05-27 09:00:00+07:00');
 
 -----------
 -- Roles --
@@ -24,13 +75,19 @@ INSERT INTO roles VALUES (
 INSERT INTO roles (name, permission, created_at, updated_at)
 VALUES (
   /* id            1 (automatic) */
-  /* name       */ 'Mentor',
-  /* permission */ 15, -- bit: 0000 0000 0000 1111
+  /* name       */ 'Educator',
+  /* permission */ 255, -- bit: 0000 0000 1111 1111
   /* created_at */ '2025-05-27 09:00:00+07:00',
   /* updated_at */ '2025-05-27 09:00:00+07:00'
 ), (
   /* id            2 (automatic) */
-  /* name       */ 'Mentee',
+  /* name       */ 'Class Manager',
+  /* permission */ 63, -- bit: 0000 0000 0011 1111
+  /* created_at */ '2025-05-27 09:00:00+07:00',
+  /* updated_at */ '2025-05-27 09:00:00+07:00'
+), (
+  /* id            3 (automatic) */
+  /* name       */ 'General User',
   /* permission */ 7, -- bit: 0000 0000 0000 0111
   /* created_at */ '2025-05-27 09:00:00+07:00',
   /* updated_at */ '2025-05-27 09:00:00+07:00'

--- a/docs/db/sevenpreneur.dbml
+++ b/docs/db/sevenpreneur.dbml
@@ -12,68 +12,42 @@ enum status_enum {
   inactive
 }
 
-enum u_stage_enum {
-  ideation
-  feasibility_analysis
-  business_planning
-  execution
-  growth
-}
-
-enum u_industry_enum {
-  agriculture
-  automotive
-  biotechnology
-  chemicals
-  construction
-  consulting
-  consumer_goods
-  education
-  energy
-  engineering
-  entertainment
-  environmental_services
-  fashion
-  financial_services
-  food_and_beverage
-  government
-  healthcare
-  hospitality
-  human_resources
-  information_technology
-  insurance
-  legal
-  logistics_and_transportation
-  manufacturing
-  media
-  mining
-  non_profit
-  pharmaceuticals
-  public_relations
-  real_estate
-  retail
-  telecommunications
-  textiles
-  tourism
-  utilities
-}
-
 ////////////
 // Tables //
 ////////////
 
+Table industries {
+  id             smallint     [primary key]
+  industry_name  varchar      [note: 'e.g. Information Technology']
+  created_at     timestamptz
+}
+
+Table entrepreneur_stages {
+  id          smallint     [primary key]
+  stage_name  varchar      [note: 'e.g. Growth']
+  created_at  timestamptz
+}
+
+Table roles {
+  id          smallint     [primary key]
+  name        varchar      [note: 'e.g. Administrator']
+  permission  smallint
+  created_at  timestamptz
+  updated_at  timestamptz
+}
+
 Table users {
-  id                  uuid             [primary key]
-  full_name           varchar          [note: 'e.g. Budi Sadikin']
-  email               varchar          [note: 'unique, e.g. budisadikin@gmail.com']
+  id                  uuid         [primary key]
+  full_name           varchar      [note: 'e.g. Budi Sadikin']
+  email               varchar      [note: 'unique, e.g. budisadikin@gmail.com']
   avatar              varchar
-  role_id             smallint         [ref: > roles.id]
+  role_id             smallint     [ref: > roles.id]
   status              status_enum
   date_of_birth       date
   learning_goal       varchar
-  entrepreneur_stage  u_stage_enum
+  entrepreneur_stage  smallint
   business_name       varchar
-  industry            u_industry_enum
+  industry_id         smallint
   created_at          timestamptz
   updated_at          timestamptz
   last_login          timestamptz
@@ -86,12 +60,4 @@ Table tokens {
   is_active   boolean
   token       text         [note: 'unique']
   created_at  timestamptz
-}
-
-Table roles {
-  id          smallint     [primary key]
-  name        varchar      [note: 'e.g. Administrator']
-  permission  smallint
-  created_at  timestamptz
-  updated_at  timestamptz
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,3 +8,74 @@ datasource db {
   url       = env("DATABASE_URL")
   directUrl = env("DIRECT_URL")
 }
+
+/////////////////
+// Enumeration //
+/////////////////
+
+enum StatusEnum {
+  ACTIVE   @map("active")
+  INACTIVE @map("inactive")
+
+  @@map("status_enum")
+}
+
+////////////
+// Models //
+////////////
+
+model Industry {
+  id            Int      @id @default(autoincrement()) @db.SmallInt
+  industry_name String   @unique @db.VarChar()
+  created_at    DateTime @default(now()) @db.Timestamptz()
+
+  @@map("industries")
+}
+
+model EntrepreneurStage {
+  id         Int      @id @default(autoincrement()) @db.SmallInt
+  stage_name String   @unique @db.VarChar()
+  created_at DateTime @default(now()) @db.Timestamptz()
+
+  @@map("entrepreneur_stages")
+}
+
+model Role {
+  id         Int      @id @default(autoincrement()) @db.SmallInt
+  name       String   @unique @db.VarChar()
+  permission Int      @db.SmallInt
+  created_at DateTime @default(now()) @db.Timestamptz()
+  updated_at DateTime @default(now()) @updatedAt @db.Timestamptz()
+
+  @@map("roles")
+}
+
+model User {
+  id                 String     @id @default(uuid()) @db.Uuid
+  full_name          String     @db.VarChar()
+  email              String     @unique @db.VarChar()
+  avatar             String?    @db.VarChar()
+  role_id            Int        @default(3) @db.SmallInt // General User
+  status             StatusEnum @default(ACTIVE)
+  date_of_birth      DateTime?  @db.Date
+  learning_goal      String?    @db.VarChar()
+  entrepreneur_stage Int?       @db.SmallInt
+  business_name      String?    @db.VarChar()
+  industry_id        Int?       @db.SmallInt
+  created_at         DateTime   @default(now()) @db.Timestamptz()
+  updated_at         DateTime   @default(now()) @updatedAt @db.Timestamptz()
+  last_login         DateTime   @default(now()) @updatedAt @db.Timestamptz()
+  deleted_at         DateTime?  @db.Timestamptz()
+
+  @@map("users")
+}
+
+model Token {
+  id         Int      @id @default(autoincrement()) @db.Integer
+  user_id    String   @db.Uuid
+  is_active  Boolean  @default(false) @db.Boolean
+  token      String   @unique @db.Text
+  created_at DateTime @default(now()) @db.Timestamptz()
+
+  @@map("tokens")
+}


### PR DESCRIPTION
Main changes:
- Enum `u_industry_enum` -> Table `industries`
- Enum `u_stage_enum` -> Table `entrepreneur_stages`

Some roles are modified/added.

The Prisma schema is also updated (was missing tables and types).

Related: SVP-28