### PR TITLE
[BE] Add CRUD for learnings table

### DIFF
--- a/docs/db/sevenpreneur-ddl.sql
+++ b/docs/db/sevenpreneur-ddl.sql
@@ -9,6 +9,12 @@ CREATE TYPE status_enum AS ENUM (
   'inactive'
 );
 
+CREATE TYPE learning_method_enum AS ENUM (
+  'online',
+  'onsite',
+  'hybrid'
+);
+
 ------------
 -- Tables --
 ------------
@@ -95,17 +101,19 @@ CREATE TABLE modules (
 );
 
 CREATE TABLE learnings (
-  id             SERIAL       PRIMARY KEY,
-  cohort_id      INTEGER      NOT NULL,
-  name           VARCHAR      NOT NULL,
-  description    VARCHAR      NOT NULL,
-  meeting_date   TIMESTAMPTZ  NOT NULL  DEFAULT CURRENT_TIMESTAMP,
-  meeting_url    VARCHAR      NOT NULL,
-  speaker_id     UUID         NOT NULL,
-  recording_url  VARCHAR      NOT NULL,
-  status         status_enum  NOT NULL,
-  created_at     TIMESTAMPTZ  NOT NULL  DEFAULT CURRENT_TIMESTAMP,
-  updated_at     TIMESTAMPTZ  NOT NULL  DEFAULT CURRENT_TIMESTAMP
+  id                SERIAL                PRIMARY KEY,
+  cohort_id         INTEGER               NOT NULL,
+  name              VARCHAR               NOT NULL,
+  description       VARCHAR               NOT NULL,
+  method            learning_method_enum  NOT NULL,
+  meeting_date      TIMESTAMPTZ           NOT NULL  DEFAULT CURRENT_TIMESTAMP,
+  meeting_url       VARCHAR                   NULL,
+  meeting_location  VARCHAR                   NULL,
+  speaker_id        UUID                      NULL,
+  recording_url     VARCHAR                   NULL,
+  status            status_enum           NOT NULL,
+  created_at        TIMESTAMPTZ           NOT NULL  DEFAULT CURRENT_TIMESTAMP,
+  updated_at        TIMESTAMPTZ           NOT NULL  DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE materials (

--- a/docs/db/sevenpreneur.dbml
+++ b/docs/db/sevenpreneur.dbml
@@ -63,18 +63,18 @@ Table tokens {
 }
 
 Table cohorts {
-  id             integer      [primary key]
-  name           varchar
-  description    varchar
-  image          varchar
-  status         status_enum
-  slug_url       varchar
-  start_date     timestamptz
-  end_date       timestamptz
-  published_at   timestamptz
-  updated_at     timestamptz
-  deleted_at     timestamptz
-  deleted_by     uuid         [ref: > users.id]
+  id            integer      [primary key]
+  name          varchar
+  description   varchar
+  image         varchar
+  status        status_enum
+  slug_url      varchar
+  start_date    timestamptz
+  end_date      timestamptz
+  published_at  timestamptz
+  updated_at    timestamptz
+  deleted_at    timestamptz
+  deleted_by    uuid         [ref: > users.id]
 }
 
 Table cohort_prices {
@@ -97,7 +97,7 @@ Table modules {
   updated_at    timestamptz
 }
 
-Table lessons {
+Table learnings {
   id             integer      [primary key]
   cohort_id      integer      [ref: > cohorts.id]
   name           varchar
@@ -113,7 +113,7 @@ Table lessons {
 
 Table materials {
   id            integer      [primary key]
-  lesson_id     integer      [ref: > lessons.id]
+  learning_id   integer      [ref: > learnings.id]
   name          varchar
   description   varchar
   document_url  varchar

--- a/docs/db/sevenpreneur.dbml
+++ b/docs/db/sevenpreneur.dbml
@@ -12,6 +12,12 @@ enum status_enum {
   inactive
 }
 
+enum learning_method_enum {
+  online
+  onsite
+  hybrid
+}
+
 ////////////
 // Tables //
 ////////////
@@ -98,17 +104,19 @@ Table modules {
 }
 
 Table learnings {
-  id             integer      [primary key]
-  cohort_id      integer      [ref: > cohorts.id]
-  name           varchar
-  description    varchar
-  meeting_date   timestamptz
-  meeting_url    varchar
-  speaker_id     uuid         [ref: > users.id]
-  recording_url  varchar
-  status         status_enum
-  created_at     timestamptz
-  updated_at     timestamptz
+  id                integer               [primary key]
+  cohort_id         integer               [ref: > cohorts.id]
+  name              varchar
+  description       varchar
+  method            learning_method_enum
+  meeting_date      timestamptz
+  meeting_url       varchar
+  meeting_location  varchar
+  speaker_id        uuid                  [ref: > users.id]
+  recording_url     varchar
+  status            status_enum
+  created_at        timestamptz
+  updated_at        timestamptz
 }
 
 Table materials {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,14 @@ enum StatusEnum {
   @@map("status_enum")
 }
 
+enum LearningMethodEnum {
+  ONLINE @map("online")
+  ONSITE @map("onsite")
+  HYBRID @map("hybrid")
+
+  @@map("learning_method_enum")
+}
+
 ////////////
 // Models //
 ////////////
@@ -139,20 +147,22 @@ model Module {
 }
 
 model Learning {
-  id            Int        @id @default(autoincrement()) @db.Integer
-  cohort        Cohort     @relation(fields: [cohort_id], references: [id])
-  cohort_id     Int        @db.Integer
-  name          String     @db.VarChar()
-  description   String     @db.VarChar()
-  meeting_date  DateTime   @default(now()) @db.Timestamptz()
-  meeting_url   String     @db.VarChar()
-  speaker       User       @relation(fields: [speaker_id], references: [id])
-  speaker_id    String     @db.Uuid
-  recording_url String     @db.VarChar()
-  status        StatusEnum
-  created_at    DateTime   @default(now()) @db.Timestamptz()
-  updated_at    DateTime   @default(now()) @updatedAt @db.Timestamptz()
-  materials     Material[]
+  id               Int                @id @default(autoincrement()) @db.Integer
+  cohort           Cohort             @relation(fields: [cohort_id], references: [id])
+  cohort_id        Int                @db.Integer
+  name             String             @db.VarChar()
+  description      String             @db.VarChar()
+  method           LearningMethodEnum
+  meeting_date     DateTime           @default(now()) @db.Timestamptz()
+  meeting_url      String?            @db.VarChar()
+  meeting_location String?            @db.VarChar()
+  speaker          User?              @relation(fields: [speaker_id], references: [id])
+  speaker_id       String?            @db.Uuid
+  recording_url    String?            @db.VarChar()
+  status           StatusEnum
+  created_at       DateTime           @default(now()) @db.Timestamptz()
+  updated_at       DateTime           @default(now()) @updatedAt @db.Timestamptz()
+  materials        Material[]
 
   @@map("learnings")
 }

--- a/src/trpc/routers/delete.ts
+++ b/src/trpc/routers/delete.ts
@@ -65,4 +65,27 @@ export const deleteRouter = createTRPCRouter({
         message: "Success",
       };
     }),
+
+  learning: administratorProcedure
+    .input(
+      z.object({
+        id: numberIsID(),
+      })
+    )
+    .mutation(async (opts) => {
+      const deletedLearning = await opts.ctx.prisma.learning.deleteMany({
+        where: {
+          id: opts.input.id,
+        },
+      });
+      if (deletedLearning.count > 1) {
+        console.error(
+          "delete.learning: More-than-one learnings are deleted at once."
+        );
+      }
+      return {
+        status: 200,
+        message: "Success",
+      };
+    }),
 });

--- a/src/trpc/routers/list.ts
+++ b/src/trpc/routers/list.ts
@@ -132,4 +132,36 @@ export const listRouter = createTRPCRouter({
         list: returnedList,
       };
     }),
+
+  learnings: loggedInProcedure
+    .input(
+      z.object({
+        cohort_id: numberIsID(),
+      })
+    )
+    .query(async (opts) => {
+      const learningsList = await opts.ctx.prisma.learning.findMany({
+        include: { speaker: true },
+        where: { cohort_id: opts.input.cohort_id },
+        orderBy: [{ meeting_date: "desc" }, { created_at: "desc" }],
+      });
+      const returnedList = learningsList.map((entry) => {
+        return {
+          id: entry.id,
+          cohort_id: entry.cohort_id,
+          name: entry.name,
+          method: entry.method,
+          meeting_date: entry.meeting_date,
+          meeting_url: entry.meeting_url,
+          meeting_location: entry.meeting_location,
+          speaker: entry.speaker,
+          status: entry.status,
+        };
+      });
+      return {
+        status: 200,
+        message: "Success",
+        list: returnedList,
+      };
+    }),
 });

--- a/src/trpc/routers/list.ts
+++ b/src/trpc/routers/list.ts
@@ -110,14 +110,12 @@ export const listRouter = createTRPCRouter({
   cohortPrices: loggedInProcedure
     .input(
       z.object({
-        id: numberIsID(),
+        cohort_id: numberIsID(),
       })
     )
     .query(async (opts) => {
       const cohortPricesList = await opts.ctx.prisma.cohortPrice.findMany({
-        where: {
-          cohort_id: opts.input.id,
-        },
+        where: { cohort_id: opts.input.cohort_id },
         orderBy: [{ amount: "asc" }, { created_at: "asc" }],
       });
       const returnedList = cohortPricesList.map((entry) => {

--- a/src/trpc/routers/read.ts
+++ b/src/trpc/routers/read.ts
@@ -159,4 +159,30 @@ export const readRouter = createTRPCRouter({
         cohortPrice: theCohortPrice,
       };
     }),
+
+  learning: loggedInProcedure
+    .input(
+      z.object({
+        id: numberIsID(),
+      })
+    )
+    .query(async (opts) => {
+      const theLearning = await opts.ctx.prisma.learning.findFirst({
+        where: {
+          id: opts.input.id,
+          // deleted_at: null,
+        },
+      });
+      if (!theLearning) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "The learning with the given ID is not found.",
+        });
+      }
+      return {
+        status: 200,
+        message: "Success",
+        learning: theLearning,
+      };
+    }),
 });


### PR DESCRIPTION
Also in this PR:
- In the `list.cohortPrices` procedure, query parameter `id` is renamed to `cohort_id`.
- New `method` and `meeting_location` columns are added into the `learnings` table.
- New `learning_method_enum` is added.
- DBML out-of-sync has been fixed.

Related: SVP-56 SVP-58 SVP-59 SVP-57 SVP-60
