### PR TITLE
[DB][BE] New tables and endpoints changes

### DIFF
--- a/docs/db/sevenpreneur.dbml
+++ b/docs/db/sevenpreneur.dbml
@@ -18,6 +18,20 @@ enum learning_method_enum {
   hybrid
 }
 
+enum category_enum {
+  cohort
+  video_course
+  ai
+}
+
+// Enumeration for the transactions table (t_*)
+
+enum t_status_enum {
+  pending
+  paid
+  failed
+}
+
 ////////////
 // Tables //
 ////////////
@@ -69,7 +83,7 @@ Table tokens {
 }
 
 Table cohorts {
-  id            integer      [primary key]
+  id            integer      [primary key, ref: <> users.id]
   name          varchar
   description   varchar
   image         varchar
@@ -141,4 +155,20 @@ Table projects {
   status        status_enum
   created_at    timestamptz
   updated_at    timestamptz
+}
+
+Table transactions {
+  id               integer        [primary key]
+  user_id          uuid           [ref: > users.id]
+  category         category_enum
+  item_id          integer        [note: 'item's ID based on category']
+  amount           decimal(12,2)
+  currency         varchar        [note: 'IDR']
+  invoice_number   varchar
+  status           t_status_enum
+  payment_method   varchar        [note: 'e.g. bank transfer, e-wallet, QR, etc']
+  payment_channel  varchar        [note: 'details of payment method']
+  paid_at          timestamptz
+  created_at       timestamptz
+  updated_at       timestamptz
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,6 +28,22 @@ enum LearningMethodEnum {
   @@map("learning_method_enum")
 }
 
+enum CategoryEnum {
+  COHORT       @map("cohort")
+  VIDEO_COURSE @map("video_course")
+  AI           @map("ai")
+
+  @@map("category_enum")
+}
+
+enum TStatusEnum {
+  PENDING @map("pending")
+  PAID    @map("paid")
+  FAILED  @map("failed")
+
+  @@map("t_status_enum")
+}
+
 ////////////
 // Models //
 ////////////
@@ -45,7 +61,7 @@ model EntrepreneurStage {
   id         Int      @id @default(autoincrement()) @db.SmallInt
   stage_name String   @unique @db.VarChar()
   created_at DateTime @default(now()) @db.Timestamptz()
-  User       User[]
+  users      User[]
 
   @@map("entrepreneur_stages")
 }
@@ -81,8 +97,10 @@ model User {
   last_login            DateTime           @default(now()) @updatedAt @db.Timestamptz()
   deleted_at            DateTime?          @db.Timestamptz()
   tokens                Token[]
-  cohorts               Cohort[]
-  learnings             Learning[]
+  deleted_cohorts       Cohort[]
+  speaker_at            Learning[]
+  transactions          Transaction[]
+  cohorts               Cohort[]           @relation("users_cohorts")
 
   @@map("users")
 }
@@ -116,6 +134,7 @@ model Cohort {
   modules       Module[]
   learnings     Learning[]
   projects      Project[]
+  users         User[]        @relation("users_cohorts")
 
   @@map("cohorts")
 }
@@ -195,4 +214,23 @@ model Project {
   updated_at   DateTime   @default(now()) @updatedAt @db.Timestamptz()
 
   @@map("projects")
+}
+
+model Transaction {
+  id              Int          @id @default(autoincrement()) @db.Integer
+  user            User         @relation(fields: [user_id], references: [id])
+  user_id         String       @db.Uuid
+  category        CategoryEnum
+  item_id         Int          @db.Integer
+  amount          Decimal      @db.Decimal(12, 2)
+  currency        String       @db.VarChar()
+  invoice_number  String       @db.VarChar()
+  status          TStatusEnum
+  payment_method  String?      @db.VarChar()
+  payment_channel String?      @db.VarChar()
+  paid_at         DateTime?    @db.Timestamptz()
+  created_at      DateTime     @default(now()) @db.Timestamptz()
+  updated_at      DateTime     @default(now()) @updatedAt @db.Timestamptz()
+
+  @@map("transactions")
 }

--- a/src/trpc/routers/list.ts
+++ b/src/trpc/routers/list.ts
@@ -3,7 +3,11 @@ import {
   createTRPCRouter,
   loggedInProcedure,
 } from "@/trpc/init";
-import { numberIsID, numberIsRoleID } from "@/trpc/utils/validation";
+import {
+  numberIsID,
+  numberIsRoleID,
+  stringIsUUID,
+} from "@/trpc/utils/validation";
 import { z } from "zod";
 
 export const listRouter = createTRPCRouter({
@@ -275,6 +279,36 @@ export const listRouter = createTRPCRouter({
           deadline_at: entry.deadline_at,
           status: entry.status,
           submission_percentage: Math.round(Math.random() * 100), // TODO: Use the actual data
+        };
+      });
+      return {
+        status: 200,
+        message: "Success",
+        list: returnedList,
+      };
+    }),
+
+  transactions: loggedInProcedure
+    .input(
+      z.object({
+        user_id: stringIsUUID(),
+      })
+    )
+    .query(async (opts) => {
+      const transactionsList = await opts.ctx.prisma.transaction.findMany({
+        where: { user_id: opts.input.user_id },
+        orderBy: [{ updated_at: "asc" }, { created_at: "asc" }],
+      });
+      const returnedList = transactionsList.map((entry) => {
+        return {
+          id: entry.id,
+          user_id: entry.user_id,
+          category: entry.category,
+          item_id: entry.item_id,
+          amount: entry.amount,
+          currency: entry.currency,
+          status: entry.status,
+          paid_at: entry.paid_at,
         };
       });
       return {

--- a/src/trpc/routers/read.ts
+++ b/src/trpc/routers/read.ts
@@ -1,4 +1,8 @@
-import { createTRPCRouter, loggedInProcedure } from "@/trpc/init";
+import {
+  baseProcedure,
+  createTRPCRouter,
+  loggedInProcedure,
+} from "@/trpc/init";
 import { numberIsID, stringIsUUID } from "@/trpc/utils/validation";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
@@ -105,7 +109,7 @@ export const readRouter = createTRPCRouter({
       };
     }),
 
-  cohort: loggedInProcedure
+  cohort: baseProcedure
     .input(
       z.object({
         id: numberIsID(),


### PR DESCRIPTION
New tables:
- `transactions`
- `users_cohorts`

New enums:
- `category_enum`
- `t_status_enum`

Changes:
- The `list.cohorts` and `read.cohort` become public.
- The `read.learnings_public` is added. It is the same as `read.learnings`, but has fewer properties.
- New `list.transactions` is added.

Related: SVP-122 SVP-123 SVP-131 SVP-132 SVP-133 SVP-134