### PR TITLE
[BE] Add secret key for public endpoints

### DIFF
--- a/example.env
+++ b/example.env
@@ -1,6 +1,9 @@
 # Selecting environment
 # DOMAIN_MODE="local"
 
+# Secret key for public endpoints
+# SECRET_KEY_PUBLIC_API="secret_key_here"
+
 # Database/Prisma-related
 # DATABASE_URL="postgresql://username:password@host:port/dbname?schema=public"
 # DIRECT_URL="postgresql://username:password@host:port/dbname?schema=public"

--- a/src/app/(www)/www/api/auth/callback/google/route.ts
+++ b/src/app/(www)/www/api/auth/callback/google/route.ts
@@ -1,4 +1,4 @@
-import { trpc } from "@/trpc/server";
+import { setSecretKey, trpc } from "@/trpc/server";
 import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 
@@ -8,6 +8,7 @@ export async function POST(request: Request) {
   const accessToken = body.tokenResponse.access_token;
 
   // --- Backend Process
+  setSecretKey(process.env.SECRET_KEY_PUBLIC_API!);
   const loggedIn = await trpc.auth.login({ accessToken });
   const sessionToken = loggedIn.token.token;
   const user = loggedIn.registered_user;

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -1,6 +1,6 @@
 "use server";
+import { setSecretKey, trpc } from "@/trpc/server";
 import { cookies } from "next/headers";
-import { trpc } from "@/trpc/server";
 
 // DELETE SESSION FOR LOGOUT
 export async function DeleteSession() {
@@ -12,6 +12,7 @@ export async function DeleteSession() {
   }
 
   // --- Request Backend Delete Token Database
+  setSecretKey(process.env.SECRET_KEY_PUBLIC_API!);
   const loggedOut = await trpc.auth.logout({ token: sessionData.value });
 
   // --- Delete token on Cookie

--- a/src/trpc/routers/README.md
+++ b/src/trpc/routers/README.md
@@ -64,8 +64,8 @@ These table below shows all routes/endpoints/procedures, categorized by object t
 | Procedure Name  | Administrator (`0`) | Educator (`1`) | Class Manager (`2`) | General User (`3`) | Public/Not Logged-In |
 | :-------------- | :-----------------: | :------------: | :-----------------: | :----------------: | :------------------: |
 | `create.cohort` |         ✅          |       ❌       |         ✅          |         ❌         |          ❌          |
-| `list.cohorts`  |         ✅          |       ✅       |         ✅          |         ✅         |          ❌          |
-| `read.cohort`   |         ✅          |       ✅       |         ✅          |         ✅         |          ❌          |
+| `list.cohorts`  |         ✅          |       ✅       |         ✅          |         ✅         |          ✅          |
+| `read.cohort`   |         ✅          |       ✅       |         ✅          |         ✅         |          ✅          |
 | `update.cohort` |         ✅          |       ❌       |         ✅          |         ❌         |          ❌          |
 | `delete.cohort` |         ✅          |       ❌       |         ✅          |         ❌         |          ❌          |
 

--- a/src/trpc/routers/auth.ts
+++ b/src/trpc/routers/auth.ts
@@ -1,7 +1,7 @@
 import {
-  baseProcedure,
   createTRPCRouter,
   loggedInProcedure,
+  publicProcedure,
 } from "@/trpc/init";
 import { GoogleTokenVerifier } from "@/trpc/utils/google_verifier";
 import { stringNotBlank } from "@/trpc/utils/validation";
@@ -11,7 +11,7 @@ import { randomBytes } from "crypto";
 import { z } from "zod";
 
 export const authRouter = createTRPCRouter({
-  login: baseProcedure
+  login: publicProcedure
     .input(
       z.object({
         accessToken: stringNotBlank(),
@@ -112,7 +112,7 @@ export const authRouter = createTRPCRouter({
     };
   }),
 
-  logout: baseProcedure
+  logout: publicProcedure
     .input(
       z.object({
         token: stringNotBlank(),

--- a/src/trpc/routers/list.ts
+++ b/src/trpc/routers/list.ts
@@ -1,7 +1,7 @@
 import {
-  baseProcedure,
   createTRPCRouter,
   loggedInProcedure,
+  publicProcedure,
 } from "@/trpc/init";
 import {
   numberIsID,
@@ -128,7 +128,7 @@ export const listRouter = createTRPCRouter({
       };
     }),
 
-  cohorts: baseProcedure.query(async (opts) => {
+  cohorts: publicProcedure.query(async (opts) => {
     let whereClause = { deleted_at: null };
     if (!opts.ctx.user) {
       whereClause = Object.assign(whereClause, {
@@ -223,7 +223,7 @@ export const listRouter = createTRPCRouter({
       };
     }),
 
-  learnings_public: baseProcedure
+  learnings_public: publicProcedure
     .input(
       z.object({
         cohort_id: numberIsID(),

--- a/src/trpc/routers/read.ts
+++ b/src/trpc/routers/read.ts
@@ -1,7 +1,7 @@
 import {
-  baseProcedure,
   createTRPCRouter,
   loggedInProcedure,
+  publicProcedure,
 } from "@/trpc/init";
 import { numberIsID, stringIsUUID } from "@/trpc/utils/validation";
 import { StatusEnum } from "@prisma/client";
@@ -111,7 +111,7 @@ export const readRouter = createTRPCRouter({
       };
     }),
 
-  cohort: baseProcedure
+  cohort: publicProcedure
     .input(
       z.object({
         id: numberIsID(),

--- a/src/trpc/server.tsx
+++ b/src/trpc/server.tsx
@@ -6,7 +6,12 @@ import { createCallerFactory, createTRPCContext } from "./init";
 import { makeQueryClient } from "./query-client";
 import { appRouter } from "./routers/_app";
 
+let secretKey: string = "";
 let sessionToken: string = "";
+
+export function setSecretKey(newSecretKey: string) {
+  secretKey = newSecretKey;
+}
 
 export function setSessionToken(newToken: string) {
   sessionToken = newToken;
@@ -15,6 +20,7 @@ export function setSessionToken(newToken: string) {
 export const getQueryClient = cache(makeQueryClient);
 const caller = createCallerFactory(appRouter)(() =>
   createTRPCContext({
+    secretKey: secretKey,
     sessionToken: sessionToken,
   })
 );


### PR DESCRIPTION
Affected endpoints:
- `auth.login`
- `auth.logout`
- `list.cohorts`
- `list.learnings_public`
- `read.cohort`

New environment variable: `SECRET_KEY_PUBLIC_API`

Needed changes on front-end components have been applied.

Related: SVP-136 SVP-137