### PR TITLE
[BE] Limit access to transactions list

### DIFF
--- a/src/trpc/init.ts
+++ b/src/trpc/init.ts
@@ -68,7 +68,7 @@ export const publicProcedure = t.procedure.use(async (opts) => {
     if (!ctx.secret) {
       throw new TRPCError({ code: "UNAUTHORIZED" });
     }
-    if (ctx.secret != process.env.SECRET_KEY_PUBLIC_API!) {
+    if (ctx.secret !== process.env.SECRET_KEY_PUBLIC_API!) {
       throw new TRPCError({ code: "UNAUTHORIZED" });
     }
   }
@@ -93,7 +93,7 @@ export const administratorProcedure = t.procedure.use(async (opts) => {
   if (!ctx.user) {
     throw new TRPCError({ code: "UNAUTHORIZED" });
   }
-  if (ctx.user.role.name != "Administrator") {
+  if (ctx.user.role.name !== "Administrator") {
     throw new TRPCError({ code: "UNAUTHORIZED" });
   }
   return opts.next({

--- a/src/trpc/routers/README.md
+++ b/src/trpc/routers/README.md
@@ -125,4 +125,6 @@ These table below shows all routes/endpoints/procedures, categorized by object t
 | Procedure Name      | Administrator (`0`) | Educator (`1`) | Class Manager (`2`) | General User (`3`) | Public/Not Logged-In |
 | :------------------ | :-----------------: | :------------: | :-----------------: | :----------------: | :------------------: |
 | `purchase.cohort`   |         ✅          |       ✅       |         ✅          |         ✅         |          ❌          |
+| `purchase.cancel`   |         ✅          |       ✅       |         ✅          |         ✅         |          ❌          |
 | `list.transactions` |         ✅          |       ✅       |         ✅          |         ✅         |          ❌          |
+| `read.transaction`  |         ✅          |       ✅       |         ✅          |         ✅         |          ❌          |

--- a/src/trpc/routers/list.ts
+++ b/src/trpc/routers/list.ts
@@ -9,14 +9,7 @@ import {
   stringIsUUID,
   stringNotBlank,
 } from "@/trpc/utils/validation";
-import {
-  CategoryEnum,
-  Cohort,
-  CohortPrice,
-  StatusEnum,
-  TStatusEnum,
-} from "@prisma/client";
-import { Decimal } from "@prisma/client/runtime/library";
+import { CategoryEnum, StatusEnum, TStatusEnum } from "@prisma/client";
 import { z } from "zod";
 
 export const listRouter = createTRPCRouter({
@@ -349,12 +342,12 @@ export const listRouter = createTRPCRouter({
       })
     )
     .query(async (opts) => {
-      let whereUser = opts.input.user_id;
+      let selectedUserId = opts.input.user_id;
       if (opts.ctx.user.role.name !== "Administrator") {
-        whereUser = opts.ctx.user.id;
+        selectedUserId = opts.ctx.user.id;
       }
       const transactionsList = await opts.ctx.prisma.transaction.findMany({
-        where: { user_id: whereUser },
+        where: { user_id: selectedUserId },
         orderBy: [{ created_at: "desc" }],
       });
 

--- a/src/trpc/routers/purchase.ts
+++ b/src/trpc/routers/purchase.ts
@@ -171,7 +171,7 @@ export const purchaseRouter = createTRPCRouter({
     )
     .mutation(async (opts) => {
       let whereClause = { id: opts.input.id };
-      if (opts.ctx.user.role.name != "Administrator") {
+      if (opts.ctx.user.role.name !== "Administrator") {
         whereClause = Object.assign(whereClause, { user_id: opts.ctx.user.id });
       }
       const theTransaction = await opts.ctx.prisma.transaction.findFirst({

--- a/src/trpc/routers/read.ts
+++ b/src/trpc/routers/read.ts
@@ -314,9 +314,9 @@ export const readRouter = createTRPCRouter({
       })
     )
     .query(async (opts) => {
-      let whereUser: string | undefined = opts.ctx.user.id;
+      let selectedUserId: string | undefined = opts.ctx.user.id;
       if (opts.ctx.user.role.name === "Administrator") {
-        whereUser = undefined;
+        selectedUserId = undefined;
       }
 
       const theTransaction = await opts.ctx.prisma.transaction.findFirst({
@@ -325,7 +325,7 @@ export const readRouter = createTRPCRouter({
         },
         where: {
           id: opts.input.id,
-          user_id: whereUser,
+          user_id: selectedUserId,
           // deleted_at: null,
         },
       });


### PR DESCRIPTION
General Users can only see their own transactions list.
Only Administrators can see all transactions list.

Also in this PR,
- Organize imports, use `!==`, and rename: `whereUser` -> `selectedUserId`
- Update role-access documentation for the routes (was missing `purchase.cancel` and `read.transaction`)

Related: SVP-164