### PR TITLE
[BE] Add pagination and search in some list endpoints

### DIFF
--- a/src/app/(www)/www/cohorts/[cohort_name]/[cohort_id]/checkout/page.tsx
+++ b/src/app/(www)/www/cohorts/[cohort_name]/[cohort_id]/checkout/page.tsx
@@ -40,7 +40,7 @@ export default async function CheckoutCohortPage({
   }));
 
   // --- Get Payment Data
-  const paymentMethodRaw = (await trpc.list.payment_channels()).list;
+  const paymentMethodRaw = (await trpc.list.paymentChannels()).list;
   const paymentMethodList = paymentMethodRaw.map((post) => ({
     ...post,
     calc_percent:

--- a/src/app/(www)/www/cohorts/page.tsx
+++ b/src/app/(www)/www/cohorts/page.tsx
@@ -18,7 +18,7 @@ export default async function CohortDiscoveryPage() {
 
   // --- Get List Cohort
   setSecretKey(secretKey!);
-  const listCohort = await trpc.list.cohorts();
+  const listCohort = await trpc.list.cohorts({});
   return (
     <div className="w-full pt-10 pb-20">
       <h2 className="font-bold">List Cohort</h2>

--- a/src/app/components/indexes/CohortListCMS.tsx
+++ b/src/app/components/indexes/CohortListCMS.tsx
@@ -32,7 +32,7 @@ export default function CohortListCMS({ sessionToken }: CohortListCMSProps) {
     data: cohortListData,
     isError: isErrorCohortList,
     isLoading: isLoadingCohortList,
-  } = trpc.list.cohorts.useQuery(undefined, { enabled: !!sessionToken });
+  } = trpc.list.cohorts.useQuery({}, { enabled: !!sessionToken });
 
   const isLoading = isLoadingCohortList;
   const isError = isErrorCohortList;

--- a/src/app/components/indexes/UserListCMS.tsx
+++ b/src/app/components/indexes/UserListCMS.tsx
@@ -25,9 +25,10 @@ export default function UserListCMS({ sessionToken }: UserListCMSProps) {
   const utils = trpc.useUtils();
 
   // --- Return data from tRPC
-  const { data, isLoading, isError } = trpc.list.users.useQuery(undefined, {
-    enabled: !!sessionToken,
-  });
+  const { data, isLoading, isError } = trpc.list.users.useQuery(
+    {},
+    { enabled: !!sessionToken }
+  );
   if (isLoading) {
     return (
       <div className="flex w-full h-full items-center justify-center text-alternative">

--- a/src/trpc/routers/README.md
+++ b/src/trpc/routers/README.md
@@ -39,15 +39,15 @@ These table below shows all routes/endpoints/procedures, categorized by object t
 
 ## Phone Country Codes ☎️
 
-| Procedure Name             | Administrator (`0`) | Educator (`1`) | Class Manager (`2`) | General User (`3`) | Public/Not Logged-In |
-| :------------------------- | :-----------------: | :------------: | :-----------------: | :----------------: | :------------------: |
-| `list.phone_country_codes` |         ✅          |       ✅       |         ✅          |         ✅         |          ❌          |
+| Procedure Name           | Administrator (`0`) | Educator (`1`) | Class Manager (`2`) | General User (`3`) | Public/Not Logged-In |
+| :----------------------- | :-----------------: | :------------: | :-----------------: | :----------------: | :------------------: |
+| `list.phoneCountryCodes` |         ✅          |       ✅       |         ✅          |         ✅         |          ❌          |
 
 ## Payment Channels 🏦
 
-| Procedure Name          | Administrator (`0`) | Educator (`1`) | Class Manager (`2`) | General User (`3`) | Public/Not Logged-In |
-| :---------------------- | :-----------------: | :------------: | :-----------------: | :----------------: | :------------------: |
-| `list.payment_channels` |         ✅          |       ✅       |         ✅          |         ✅         |          ❌          |
+| Procedure Name         | Administrator (`0`) | Educator (`1`) | Class Manager (`2`) | General User (`3`) | Public/Not Logged-In |
+| :--------------------- | :-----------------: | :------------: | :-----------------: | :----------------: | :------------------: |
+| `list.paymentChannels` |         ✅          |       ✅       |         ✅          |         ✅         |          ❌          |
 
 ## Users 👤
 

--- a/src/trpc/routers/list.ts
+++ b/src/trpc/routers/list.ts
@@ -65,7 +65,7 @@ export const listRouter = createTRPCRouter({
     };
   }),
 
-  phone_country_codes: loggedInProcedure.query(async (opts) => {
+  phoneCountryCodes: loggedInProcedure.query(async (opts) => {
     const codeList = await opts.ctx.prisma.phoneCountryCode.findMany();
     const returnedList = codeList.map((entry) => {
       return {
@@ -82,7 +82,7 @@ export const listRouter = createTRPCRouter({
     };
   }),
 
-  payment_channels: loggedInProcedure
+  paymentChannels: loggedInProcedure
     .input(z.object({ method: stringNotBlank().optional() }).optional())
     .query(async (opts) => {
       const channelList = await opts.ctx.prisma.paymentChannel.findMany({

--- a/src/trpc/utils/validation.ts
+++ b/src/trpc/utils/validation.ts
@@ -29,3 +29,8 @@ export function numberIsRoleID(): z.ZodNumber {
   // Administrator role has ID 0
   return z.number().finite().min(0);
 }
+
+export function numberIsPositive(): z.ZodNumber {
+  // Number should be 1 or bigger
+  return z.number().finite().min(1);
+}


### PR DESCRIPTION
The pagination is optional. Without setting the page size, no pagination is used (all rows are returned instead).

Add pagination and search:
- `list.users`
- `list.cohorts`

Only add pagination:
- `list.transactions`

Also in this PR, endpoint name casing are fixed:
- `list.phone_country_codes` -> `list.phoneCountryCodes`
- `list.payment_channels` -> `list.paymentChannels`

Related: SVP-167