### PR TITLE
[DB][BE] Support non-text WhatsApp messages

### DIFF
--- a/docs/db/sevenpreneur-ddl.sql
+++ b/docs/db/sevenpreneur-ddl.sql
@@ -129,6 +129,25 @@ CREATE TYPE wac_sender_type AS ENUM (
   'admin'
 );
 
+CREATE TYPE wac_type AS ENUM (
+  'audio',
+  'button',
+  'contacts',
+  'document',
+  'edit',
+  'image',
+  'interactive',
+  'location',
+  'order',
+  'reaction',
+  'revoke',
+  'sticker',
+  'system',
+  'text',
+  'unsupported',
+  'video'
+);
+
 CREATE TYPE wac_status AS ENUM (
   'sent',
   'delivered',
@@ -671,7 +690,9 @@ CREATE TABLE wa_chats (
   direction     wac_direction    NOT NULL,
   sender_type   wac_sender_type  NOT NULL,
   reply_to_id   CHAR(21)             NULL,
+  type          wac_type         NOT NULL,
   message       VARCHAR          NOT NULL,
+  attachment    JSON                 NULL,
   status        wac_status           NULL,
   sent_at       TIMESTAMPTZ          NULL,
   delivered_at  TIMESTAMPTZ          NULL,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -170,6 +170,27 @@ enum WACSenderType {
   @@map("wac_sender_type")
 }
 
+enum WACType {
+  AUDIO       @map("audio")
+  BUTTON      @map("button")
+  CONTACTS    @map("contacts")
+  DOCUMENT    @map("document")
+  EDIT        @map("edit")
+  IMAGE       @map("image")
+  INTERACTIVE @map("interactive")
+  LOCATION    @map("location")
+  ORDER       @map("order")
+  REACTION    @map("reaction")
+  REVOKE      @map("revoke")
+  STICKER     @map("sticker")
+  SYSTEM      @map("system")
+  TEXT        @map("text")
+  UNSUPPORTED @map("unsupported")
+  VIDEO       @map("video")
+
+  @@map("wac_type")
+}
+
 enum WACStatus {
   SENT      @map("sent")
   DELIVERED @map("delivered")
@@ -897,7 +918,9 @@ model WAChat {
   sender_type  WACSenderType
   reply_to     WAChat?          @relation("reply", fields: [reply_to_id], references: [id])
   reply_to_id  String?          @db.Char(21)
+  type         WACType
   message      String           @db.VarChar()
+  attachment   Json?            @db.Json
   status       WACStatus?
   sent_at      DateTime?        @db.Timestamptz()
   delivered_at DateTime?        @db.Timestamptz()

--- a/src/app/(api)/api/whatsapp/webhook/route.ts
+++ b/src/app/(api)/api/whatsapp/webhook/route.ts
@@ -1,4 +1,6 @@
 import GetPrismaClient from "@/lib/prisma";
+import { WhatsappAttachmentAllTypes } from "@/lib/whatsapp-types";
+import { WACType } from "@prisma/client";
 import { NextRequest, NextResponse } from "next/server";
 import { WhatsAppWebhookBody } from "./type.wa.webhook";
 import { appendChatFromUser, updateStatusByMessageID } from "./util.wa.webhook";
@@ -52,23 +54,47 @@ export async function POST(req: NextRequest) {
           userProfileName = change.value.contacts[0].profile.name;
         }
         for (const msg of change.value.messages) {
-          // Only accept text messages for now
-          if (msg.type !== "text") {
-            continue;
+          let messageType = WACType.UNSUPPORTED as WACType;
+          let message = "";
+          let attachment = undefined as WhatsappAttachmentAllTypes;
+
+          if (msg.type == "audio") {
+            messageType = WACType.AUDIO;
+            attachment = msg.audio;
+          } else if (msg.type == "contacts") {
+            messageType = WACType.CONTACTS;
+            attachment = msg.contacts;
+          } else if (msg.type == "document") {
+            messageType = WACType.DOCUMENT;
+            attachment = msg.document;
+          } else if (msg.type == "image") {
+            messageType = WACType.IMAGE;
+            attachment = msg.image;
+          } else if (msg.type == "sticker") {
+            messageType = WACType.STICKER;
+            attachment = msg.sticker;
+          } else if (msg.type == "text") {
+            messageType = WACType.TEXT;
+            message = msg.text.body;
+          } else if (msg.type == "video") {
+            messageType = WACType.VIDEO;
+            attachment = msg.video;
+          } else {
+            continue; // Skip other message types for now
           }
 
-          if (msg.type == "text") {
-            const isSuccess = await appendChatFromUser(
-              prisma,
-              userProfileName,
-              msg.from,
-              msg.id,
-              msg.text.body,
-              msg.timestamp
-            );
-            if (!isSuccess) {
-              return new NextResponse(undefined, { status: 500 });
-            }
+          const isSuccess = await appendChatFromUser(
+            prisma,
+            userProfileName,
+            msg.from,
+            msg.id,
+            messageType,
+            message,
+            attachment,
+            msg.timestamp
+          );
+          if (!isSuccess) {
+            return new NextResponse(undefined, { status: 500 });
           }
         }
       }

--- a/src/app/(api)/api/whatsapp/webhook/type.wa.webhook.ts
+++ b/src/app/(api)/api/whatsapp/webhook/type.wa.webhook.ts
@@ -1,3 +1,12 @@
+import {
+  WhatsappAttachmentAudio,
+  WhatsappAttachmentContacts,
+  WhatsappAttachmentDocument,
+  WhatsappAttachmentImage,
+  WhatsappAttachmentSticker,
+  WhatsappAttachmentVideo,
+} from "@/lib/whatsapp-types";
+
 // WhatsApp Webhook //
 
 type WhatsAppWebhookOtherFieldType =
@@ -40,21 +49,15 @@ export type WhatsAppWebhookBody = {
 // messages Webhook //
 
 type WhatsAppWebhookOtherMessageType =
-  | "audio"
   | "button"
-  | "contacts"
-  | "document"
   | "edit"
-  | "image"
   | "interactive"
   | "location"
   | "order"
   | "reaction"
   | "revoke"
-  | "sticker"
   | "system"
-  | "unsupported"
-  | "video";
+  | "unsupported";
 
 export type WhatsAppWebhookMessageStatusType =
   | "delivered"
@@ -80,10 +83,52 @@ export type WhatsAppWebhookMessage = {
         from: string;
         id: string;
         timestamp: string;
+        type: "audio";
+        audio: WhatsappAttachmentAudio;
+      }
+    | {
+        from: string;
+        id: string;
+        timestamp: string;
+        type: "contacts";
+        contacts: WhatsappAttachmentContacts;
+      }
+    | {
+        from: string;
+        id: string;
+        timestamp: string;
+        type: "document";
+        document: WhatsappAttachmentDocument;
+      }
+    | {
+        from: string;
+        id: string;
+        timestamp: string;
+        type: "image";
+        image: WhatsappAttachmentImage;
+      }
+    | {
+        from: string;
+        id: string;
+        timestamp: string;
+        type: "sticker";
+        sticker: WhatsappAttachmentSticker;
+      }
+    | {
+        from: string;
+        id: string;
+        timestamp: string;
         type: "text";
         text: {
           body: string;
         };
+      }
+    | {
+        from: string;
+        id: string;
+        timestamp: string;
+        type: "video";
+        video: WhatsappAttachmentVideo;
       }
     | {
         from: string;

--- a/src/app/(api)/api/whatsapp/webhook/util.wa.webhook.ts
+++ b/src/app/(api)/api/whatsapp/webhook/util.wa.webhook.ts
@@ -1,4 +1,5 @@
 import GetPrismaClient from "@/lib/prisma";
+import { WhatsappAttachmentAllTypes } from "@/lib/whatsapp-types";
 import {
   WACDirection,
   WACSenderType,
@@ -42,7 +43,9 @@ export async function appendChatFromUser(
   full_name: string,
   phone_number: string,
   wam_id: string,
+  type: WACType,
   message: string,
+  attachment: WhatsappAttachmentAllTypes,
   created_at: string
 ) {
   const waConversation = await getOrCreateConversation(
@@ -72,8 +75,9 @@ export async function appendChatFromUser(
       wam_id: wam_id,
       direction: WACDirection.INBOUND,
       sender_type: WACSenderType.USER,
-      type: WACType.TEXT,
+      type: type,
       message: message,
+      attachment: attachment,
       created_at: createdAtAsDate,
     },
   });

--- a/src/app/(api)/api/whatsapp/webhook/util.wa.webhook.ts
+++ b/src/app/(api)/api/whatsapp/webhook/util.wa.webhook.ts
@@ -1,5 +1,10 @@
 import GetPrismaClient from "@/lib/prisma";
-import { WACDirection, WACSenderType, WACStatus } from "@prisma/client";
+import {
+  WACDirection,
+  WACSenderType,
+  WACStatus,
+  WACType,
+} from "@prisma/client";
 import { WhatsAppWebhookMessageStatusType } from "./type.wa.webhook";
 
 async function getOrCreateConversation(
@@ -67,6 +72,7 @@ export async function appendChatFromUser(
       wam_id: wam_id,
       direction: WACDirection.INBOUND,
       sender_type: WACSenderType.USER,
+      type: WACType.TEXT,
       message: message,
       created_at: createdAtAsDate,
     },
@@ -108,6 +114,7 @@ export async function updateStatusByMessageID(
         wam_id: wam_id,
         direction: WACDirection.OUTBOUND,
         sender_type: WACSenderType.ADMIN,
+        type: WACType.TEXT,
         message: "",
         created_at: updatedAtAsDate,
       },

--- a/src/lib/whatsapp-types.ts
+++ b/src/lib/whatsapp-types.ts
@@ -1,0 +1,98 @@
+export type WhatsappAttachmentAllTypes =
+  | WhatsappAttachmentAudio
+  | WhatsappAttachmentContacts
+  | WhatsappAttachmentDocument
+  | WhatsappAttachmentImage
+  | WhatsappAttachmentSticker
+  | WhatsappAttachmentVideo
+  | WhatsappAttachmentText;
+
+export type WhatsappAttachmentAudio = {
+  mime_type: string;
+  sha256: string;
+  id: string;
+  url: string;
+  voice: boolean;
+};
+
+export type WhatsappAttachmentContacts = {
+  addresses?: [
+    {
+      city?: string;
+      country?: string;
+      country_code?: string;
+      state?: string;
+      street?: string;
+      type?: string;
+      zip?: string;
+    }
+  ];
+  birthday?: string;
+  emails?: [
+    {
+      email?: string;
+      type?: string;
+    }
+  ];
+  name?: {
+    formatted_name?: string;
+    first_name?: string;
+    last_name?: string;
+    middle_name?: string;
+    suffix?: string;
+    prefix?: string;
+  };
+  org?: {
+    company?: string;
+    department?: string;
+    title?: string;
+  };
+  phones?: [
+    {
+      phone?: string;
+      wa_id?: string;
+      type?: string;
+    }
+  ];
+  urls?: [
+    {
+      url?: string;
+      type?: string;
+    }
+  ];
+}[];
+
+export type WhatsappAttachmentDocument = {
+  caption: string;
+  filename: string;
+  mime_type: string;
+  sha256: string;
+  id: string;
+  url: string;
+};
+
+export type WhatsappAttachmentImage = {
+  caption: string;
+  mime_type: string;
+  sha256: string;
+  id: string;
+  url: string;
+};
+
+export type WhatsappAttachmentSticker = {
+  mime_type: string;
+  sha256: string;
+  id: string;
+  url: string;
+  animated: boolean;
+};
+
+export type WhatsappAttachmentVideo = {
+  caption: string;
+  mime_type: string;
+  sha256: string;
+  id: string;
+  url: string;
+};
+
+export type WhatsappAttachmentText = undefined; // will be NULL in database

--- a/src/trpc/routers/wa/list.wa.ts
+++ b/src/trpc/routers/wa/list.wa.ts
@@ -10,6 +10,7 @@ import {
 } from "@/trpc/utils/validation";
 import { Prisma, WALeadStatus } from "@prisma/client";
 import z from "zod";
+import { convertToWhatsAppChatWithAttachment } from "./type.wa";
 
 export const listWA = {
   conversations: administratorProcedure
@@ -143,10 +144,12 @@ ORDER BY last_message_at DESC`;
         take: opts.input.size,
       });
 
+      const returnedList = convertToWhatsAppChatWithAttachment(waChatsList);
+
       return {
         code: STATUS_OK,
         message: "Success",
-        list: waChatsList,
+        list: returnedList,
       };
     }),
 };

--- a/src/trpc/routers/wa/send.wa.ts
+++ b/src/trpc/routers/wa/send.wa.ts
@@ -3,7 +3,7 @@ import { whatsappMessageRequest } from "@/lib/whatsapp";
 import { administratorProcedure } from "@/trpc/init";
 import { readFailedNotFound } from "@/trpc/utils/errors";
 import { stringIsNanoid, stringNotBlank } from "@/trpc/utils/validation";
-import { WACDirection, WACSenderType } from "@prisma/client";
+import { WACDirection, WACSenderType, WACType } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
 import z from "zod";
 
@@ -54,6 +54,7 @@ export const sendWA = {
           wam_id: messageId,
           direction: WACDirection.OUTBOUND,
           sender_type: WACSenderType.ADMIN,
+          type: WACType.TEXT,
           message: opts.input.message,
         },
       });

--- a/src/trpc/routers/wa/type.wa.ts
+++ b/src/trpc/routers/wa/type.wa.ts
@@ -1,0 +1,64 @@
+import {
+  WhatsappAttachmentAudio,
+  WhatsappAttachmentContacts,
+  WhatsappAttachmentDocument,
+  WhatsappAttachmentImage,
+  WhatsappAttachmentSticker,
+  WhatsappAttachmentText,
+  WhatsappAttachmentVideo,
+} from "@/lib/whatsapp-types";
+import { WACType } from "@prisma/client";
+import { JsonValue } from "@prisma/client/runtime/library";
+
+export type WhatsAppChatWithAttachment<
+  T extends { type: WACType; attachment: JsonValue }
+> = Omit<T, "type" | "attachment"> &
+  (
+    | {
+        type: typeof WACType.AUDIO;
+        attachment: WhatsappAttachmentAudio;
+      }
+    | {
+        type: typeof WACType.CONTACTS;
+        attachment: WhatsappAttachmentContacts;
+      }
+    | {
+        type: typeof WACType.DOCUMENT;
+        attachment: WhatsappAttachmentDocument;
+      }
+    | {
+        type: typeof WACType.IMAGE;
+        attachment: WhatsappAttachmentImage;
+      }
+    | {
+        type: typeof WACType.STICKER;
+        attachment: WhatsappAttachmentSticker;
+      }
+    | {
+        type: typeof WACType.TEXT;
+        attachment: WhatsappAttachmentText;
+      }
+    | {
+        type: typeof WACType.VIDEO;
+        attachment: WhatsappAttachmentVideo;
+      }
+    | {
+        type:
+          | typeof WACType.BUTTON
+          | typeof WACType.EDIT
+          | typeof WACType.INTERACTIVE
+          | typeof WACType.LOCATION
+          | typeof WACType.ORDER
+          | typeof WACType.REACTION
+          | typeof WACType.REVOKE
+          | typeof WACType.SYSTEM
+          | typeof WACType.UNSUPPORTED;
+        attachment: JsonValue | undefined;
+      }
+  );
+
+export function convertToWhatsAppChatWithAttachment<
+  T extends { type: WACType; attachment: JsonValue }
+>(list: T[]) {
+  return list as WhatsAppChatWithAttachment<T>[];
+}


### PR DESCRIPTION
[messages webhook reference | Developer Documentation](https://developers.facebook.com/documentation/business-messaging/whatsapp/webhooks/reference/messages/?locale=en_US)

New enum:
- `wac_type` (e.g. `text`, `image`, `document`)

(Prefix `wac_` is for WhatsApp chat.)

New columns on `wa_chats`:
- `type`
- `attachment`

Affected endpoints:
- `/whatsapp/webhook` (POST)
- `list.wa.chats`

Related: SVP-268