### PR TITLE
[BE] Use unknown instead when constructing attachment types

### DIFF
--- a/src/trpc/routers/wa/type.wa.ts
+++ b/src/trpc/routers/wa/type.wa.ts
@@ -8,10 +8,9 @@ import {
   WhatsappAttachmentVideo,
 } from "@/lib/whatsapp-types";
 import { WACType } from "@prisma/client";
-import { JsonValue } from "@prisma/client/runtime/library";
 
 export type WhatsAppChatWithAttachment<
-  T extends { type: WACType; attachment: JsonValue }
+  T extends { type: WACType; attachment: unknown }
 > = Omit<T, "type" | "attachment"> &
   (
     | {
@@ -53,12 +52,12 @@ export type WhatsAppChatWithAttachment<
           | typeof WACType.REVOKE
           | typeof WACType.SYSTEM
           | typeof WACType.UNSUPPORTED;
-        attachment: JsonValue | undefined;
+        attachment: unknown;
       }
   );
 
 export function convertToWhatsAppChatWithAttachment<
-  T extends { type: WACType; attachment: JsonValue }
+  T extends { type: WACType; attachment: unknown }
 >(list: T[]) {
   return list as WhatsAppChatWithAttachment<T>[];
 }

--- a/src/trpc/routers/wa/type.wa.ts
+++ b/src/trpc/routers/wa/type.wa.ts
@@ -9,52 +9,52 @@ import {
 } from "@/lib/whatsapp-types";
 import { WACType } from "@prisma/client";
 
+export type WhatsAppTypeAttachmentPairUnion =
+  | {
+      type: typeof WACType.AUDIO;
+      attachment: WhatsappAttachmentAudio;
+    }
+  | {
+      type: typeof WACType.CONTACTS;
+      attachment: WhatsappAttachmentContacts;
+    }
+  | {
+      type: typeof WACType.DOCUMENT;
+      attachment: WhatsappAttachmentDocument;
+    }
+  | {
+      type: typeof WACType.IMAGE;
+      attachment: WhatsappAttachmentImage;
+    }
+  | {
+      type: typeof WACType.STICKER;
+      attachment: WhatsappAttachmentSticker;
+    }
+  | {
+      type: typeof WACType.TEXT;
+      attachment: WhatsappAttachmentText;
+    }
+  | {
+      type: typeof WACType.VIDEO;
+      attachment: WhatsappAttachmentVideo;
+    }
+  | {
+      type:
+        | typeof WACType.BUTTON
+        | typeof WACType.EDIT
+        | typeof WACType.INTERACTIVE
+        | typeof WACType.LOCATION
+        | typeof WACType.ORDER
+        | typeof WACType.REACTION
+        | typeof WACType.REVOKE
+        | typeof WACType.SYSTEM
+        | typeof WACType.UNSUPPORTED;
+      attachment: unknown;
+    };
+
 export type WhatsAppChatWithAttachment<
   T extends { type: WACType; attachment: unknown }
-> = Omit<T, "type" | "attachment"> &
-  (
-    | {
-        type: typeof WACType.AUDIO;
-        attachment: WhatsappAttachmentAudio;
-      }
-    | {
-        type: typeof WACType.CONTACTS;
-        attachment: WhatsappAttachmentContacts;
-      }
-    | {
-        type: typeof WACType.DOCUMENT;
-        attachment: WhatsappAttachmentDocument;
-      }
-    | {
-        type: typeof WACType.IMAGE;
-        attachment: WhatsappAttachmentImage;
-      }
-    | {
-        type: typeof WACType.STICKER;
-        attachment: WhatsappAttachmentSticker;
-      }
-    | {
-        type: typeof WACType.TEXT;
-        attachment: WhatsappAttachmentText;
-      }
-    | {
-        type: typeof WACType.VIDEO;
-        attachment: WhatsappAttachmentVideo;
-      }
-    | {
-        type:
-          | typeof WACType.BUTTON
-          | typeof WACType.EDIT
-          | typeof WACType.INTERACTIVE
-          | typeof WACType.LOCATION
-          | typeof WACType.ORDER
-          | typeof WACType.REACTION
-          | typeof WACType.REVOKE
-          | typeof WACType.SYSTEM
-          | typeof WACType.UNSUPPORTED;
-        attachment: unknown;
-      }
-  );
+> = Omit<T, "type" | "attachment"> & WhatsAppTypeAttachmentPairUnion;
 
 export function convertToWhatsAppChatWithAttachment<
   T extends { type: WACType; attachment: unknown }


### PR DESCRIPTION
This PR fixes this problem:

> Type instantiation is excessively deep and possibly infinite.

Since `attachment` property's type would be set at the end, using `unknown` should be fine instead of Prisma's `JsonValue`.

Also in this PR,
- Factor out WhatsApp type-attachment pair union (`WhatsAppTypeAttachmentPairUnion`)