### PR TITLE
[BE] Process and upload WA image to Supabase storage on webhook

### DIFF
--- a/src/app/(api)/api/whatsapp/webhook/process.wa.webhook.ts
+++ b/src/app/(api)/api/whatsapp/webhook/process.wa.webhook.ts
@@ -1,0 +1,85 @@
+import GetPrismaClient from "@/lib/prisma";
+import { supabase } from "@/lib/supabase";
+import { WhatsappAttachmentImage } from "@/lib/whatsapp-types";
+
+export async function processImageMessage(
+  wam_id: string,
+  media_id: string,
+  attachment: WhatsappAttachmentImage
+) {
+  try {
+    const accessToken = process.env.WHATSAPP_ACCESS_TOKEN;
+
+    // 1. Fetch media URL from WhatsApp Graph API
+    const mediaRes = await fetch(
+      `https://graph.facebook.com/v21.0/${media_id}`,
+      {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      }
+    );
+    if (!mediaRes.ok) {
+      console.error(
+        `[WA Image] Failed to fetch media URL for ${media_id}: ${mediaRes.statusText}`
+      );
+      return;
+    }
+    const mediaData: { url: string; mime_type: string } = await mediaRes.json();
+    const { url: mediaUrl, mime_type: mimeType } = mediaData;
+
+    // 2. Download binary from WhatsApp CDN
+    const binaryRes = await fetch(mediaUrl, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    if (!binaryRes.ok) {
+      console.error(
+        `[WA Image] Failed to download binary for ${media_id}: ${binaryRes.statusText}`
+      );
+      return;
+    }
+    const binary = await binaryRes.arrayBuffer();
+
+    // 3. Upload to Supabase storage under whatsapp/ folder
+    const ext = mimeType.split("/")[1] || "jpg";
+    const filePath = `whatsapp/images/${Date.now()}_${media_id}.${ext}`;
+    const { error: uploadError } = await supabase.storage
+      .from("sevenpreneur")
+      .upload(filePath, binary, {
+        contentType: mimeType,
+        cacheControl: "3600",
+        upsert: false,
+      });
+    if (uploadError) {
+      console.error(
+        `[WA Image] Supabase upload error for ${media_id}: ${uploadError.message}`
+      );
+      return;
+    }
+
+    // 4. Get public URL
+    const { data: publicUrlData } = supabase.storage
+      .from("sevenpreneur")
+      .getPublicUrl(filePath);
+    const storageUrl = publicUrlData.publicUrl;
+
+    // 5. Update attachment in DB with storage_url
+    const prisma = GetPrismaClient();
+    await prisma.wAChat.updateMany({
+      data: {
+        attachment: {
+          ...attachment,
+          storage_url: storageUrl,
+        },
+      },
+      where: { wam_id },
+    });
+
+    console.log(
+      `[WA Image] Successfully processed image for wam_id ${wam_id}: ${storageUrl}`
+    );
+  } catch (err) {
+    console.error(
+      `[WA Image] Unexpected error processing image for wam_id ${wam_id}:`,
+      err
+    );
+  }
+}

--- a/src/app/(api)/api/whatsapp/webhook/route.ts
+++ b/src/app/(api)/api/whatsapp/webhook/route.ts
@@ -4,7 +4,11 @@ import { WACType } from "@prisma/client";
 import { NextRequest, NextResponse } from "next/server";
 import { processImageMessage } from "./process.wa.webhook";
 import { WhatsAppWebhookBody } from "./type.wa.webhook";
-import { appendChatFromUser, updateStatusByMessageID } from "./util.wa.webhook";
+import {
+  appendChatFromUser,
+  saveWhatsappAttachment,
+  updateStatusByMessageID,
+} from "./util.wa.webhook";
 
 export async function GET(req: NextRequest) {
   const VERIFY_TOKEN = process.env.WHATSAPP_WEBHOOK_VERIFICATION_TOKEN;
@@ -62,24 +66,29 @@ export async function POST(req: NextRequest) {
           if (msg.type == "audio") {
             messageType = WACType.AUDIO;
             attachment = msg.audio;
+            saveWhatsappAttachment(prisma, "audio", msg.audio, msg.id);
           } else if (msg.type == "contacts") {
             messageType = WACType.CONTACTS;
             attachment = msg.contacts;
           } else if (msg.type == "document") {
             messageType = WACType.DOCUMENT;
             attachment = msg.document;
+            saveWhatsappAttachment(prisma, "document", msg.document, msg.id);
           } else if (msg.type == "image") {
             messageType = WACType.IMAGE;
             attachment = msg.image;
+            saveWhatsappAttachment(prisma, "image", msg.image, msg.id);
           } else if (msg.type == "sticker") {
             messageType = WACType.STICKER;
             attachment = msg.sticker;
+            saveWhatsappAttachment(prisma, "sticker", msg.sticker, msg.id);
           } else if (msg.type == "text") {
             messageType = WACType.TEXT;
             message = msg.text.body;
           } else if (msg.type == "video") {
             messageType = WACType.VIDEO;
             attachment = msg.video;
+            saveWhatsappAttachment(prisma, "video", msg.video, msg.id);
           } else {
             continue; // Skip other message types for now
           }

--- a/src/app/(api)/api/whatsapp/webhook/route.ts
+++ b/src/app/(api)/api/whatsapp/webhook/route.ts
@@ -2,6 +2,7 @@ import GetPrismaClient from "@/lib/prisma";
 import { WhatsappAttachmentAllTypes } from "@/lib/whatsapp-types";
 import { WACType } from "@prisma/client";
 import { NextRequest, NextResponse } from "next/server";
+import { processImageMessage } from "./process.wa.webhook";
 import { WhatsAppWebhookBody } from "./type.wa.webhook";
 import { appendChatFromUser, updateStatusByMessageID } from "./util.wa.webhook";
 
@@ -94,7 +95,18 @@ export async function POST(req: NextRequest) {
             msg.timestamp
           );
           if (!isSuccess) {
-            return new NextResponse(undefined, { status: 500 });
+            // WhatsApp akan retry webhook jika dapat response non-200.
+            // Artinya jika satu message gagal diproses, WhatsApp akan kirim ulang seluruh payload
+            // dan message yang sudah berhasil di loop sebelumnya akan diproses duplikat.
+            console.error(`[WA Webhook] Failed to process message ${msg.id}`);
+            continue;
+          }
+
+          // Fire background process to upload image binary to Supabase storage
+          if (msg.type === "image") {
+            processImageMessage(msg.id, msg.image.id, msg.image).catch((err) =>
+              console.error("[WA Image] Background process error:", err)
+            );
           }
         }
       }

--- a/src/app/(api)/api/whatsapp/webhook/util.wa.webhook.ts
+++ b/src/app/(api)/api/whatsapp/webhook/util.wa.webhook.ts
@@ -1,4 +1,9 @@
 import GetPrismaClient from "@/lib/prisma";
+import { supabase } from "@/lib/supabase";
+import {
+  whatsappDownloadMediaRequest,
+  whatsappGetMediaURLRequest,
+} from "@/lib/whatsapp";
 import { WhatsappAttachmentAllTypes } from "@/lib/whatsapp-types";
 import {
   WACDirection,
@@ -172,4 +177,45 @@ export async function updateStatusByMessageID(
   }
 
   return true;
+}
+
+export async function saveWhatsappAttachment(
+  prisma: ReturnType<typeof GetPrismaClient>,
+  media_type: "audio" | "document" | "image" | "sticker" | "video",
+  attachment: object & { id: string },
+  wam_id: string
+) {
+  const getMediaURL = await whatsappGetMediaURLRequest(attachment.id);
+  const fileBuffer = await whatsappDownloadMediaRequest(getMediaURL.url);
+
+  const fileExt = getMediaURL.mime_type.split("/")[1] || "bin";
+  const fileName = `${Date.now()}_${attachment.id}.${fileExt}`;
+  const filePath = `whatsapp/${media_type}s/${fileName}`;
+  const { error } = await supabase.storage
+    .from("sevenpreneur")
+    .upload(filePath, fileBuffer, {
+      contentType: getMediaURL.mime_type,
+      cacheControl: "3600",
+      upsert: false,
+    });
+
+  if (error) {
+    console.error("Supabase upload error:", error.message);
+  }
+
+  const { data } = supabase.storage.from("sevenpreneur").getPublicUrl(filePath);
+
+  const updatedChat = await prisma.wAChat.updateManyAndReturn({
+    data: {
+      attachment: {
+        ...attachment,
+        storage_url: data.publicUrl,
+      },
+    },
+    where: { wam_id: wam_id },
+  });
+  if (updatedChat.length != 1) {
+    console.error("Failed to update chat.");
+    return false;
+  }
 }

--- a/src/components/messages/WhatsappChatItemCMS.tsx
+++ b/src/components/messages/WhatsappChatItemCMS.tsx
@@ -78,9 +78,9 @@ export default function WhatsappChatItemCMS(props: WhatsappChatItemCMSProps) {
         </WhatsappChatBubbleCMS>
 
         {/* Preview image */}
-        {isImagePreviewOpen && (
+        {isImagePreviewOpen && props.chat.attachment.storage_url && (
           <WhatsappImagePreviewCMS
-            imageURL="https://tskubmriuclmbcfmaiur.supabase.co/storage/v1/object/public/sevenpreneur/cohort/1765529832399.webp"
+            imageURL={props.chat.attachment.storage_url}
             imageCaption={props.chat.attachment.caption}
             isOpen={isImagePreviewOpen}
             onClose={() => setIsImagePreviewOpen(false)}

--- a/src/components/messages/WhatsappChatItemCMS.tsx
+++ b/src/components/messages/WhatsappChatItemCMS.tsx
@@ -46,43 +46,49 @@ export default function WhatsappChatItemCMS(props: WhatsappChatItemCMSProps) {
     );
   }
 
-  // if (props.chat.type === "IMAGE") {
-  //   return (
-  //     <>
-  //       <WhatsappChatBubbleCMS
-  //         chatDirection={props.chatDirection}
-  //         chatStatus={props.chatStatus}
-  //         iconStatus={iconStatus}
-  //         timestampStatus={timestampStatus}
-  //         createdAt={props.createdAt}
-  //       >
-  //         <div className="image flex flex-col w-full gap-1 pb-1">
-  //           <Image
-  //             className="w-full h-full rounded-sm cursor-pointer"
-  //             src="https://tskubmriuclmbcfmaiur.supabase.co/storage/v1/object/public/sevenpreneur/cohort/1765529832399.webp"
-  //             alt={props.chat.attachment.caption || "Image Whatsapp"}
-  //             width={300}
-  //             height={300}
-  //             onClick={() => setIsImagePreviewOpen(true)}
-  //           />
-  //           {!!props.chat.attachment.caption && (
-  //             <p className="p-1">{props.chat.attachment.caption}</p>
-  //           )}
-  //         </div>
-  //       </WhatsappChatBubbleCMS>
+  if (props.chat.type === "IMAGE") {
+    return (
+      <>
+        <WhatsappChatBubbleCMS
+          chatDirection={props.chatDirection}
+          chatStatus={props.chatStatus}
+          iconStatus={iconStatus}
+          timestampStatus={timestampStatus}
+          createdAt={props.createdAt}
+        >
+          <div className="image flex flex-col w-full gap-1 pb-1">
+            {props.chat.attachment.storage_url ? (
+              <Image
+                className="w-full h-full rounded-sm cursor-pointer"
+                src={props.chat.attachment.storage_url}
+                alt={props.chat.attachment.caption || "Image Whatsapp"}
+                width={300}
+                height={300}
+                onClick={() => setIsImagePreviewOpen(true)}
+              />
+            ) : (
+              <p className="px-2 italic text-muted-foreground">
+                Image not found
+              </p>
+            )}
+            {!!props.chat.attachment.caption && (
+              <p className="p-1">{props.chat.attachment.caption}</p>
+            )}
+          </div>
+        </WhatsappChatBubbleCMS>
 
-  //       {/* Preview image */}
-  //       {isImagePreviewOpen && (
-  //         <WhatsappImagePreviewCMS
-  //           imageURL="https://tskubmriuclmbcfmaiur.supabase.co/storage/v1/object/public/sevenpreneur/cohort/1765529832399.webp"
-  //           imageCaption={props.chat.attachment.caption}
-  //           isOpen={isImagePreviewOpen}
-  //           onClose={() => setIsImagePreviewOpen(false)}
-  //         />
-  //       )}
-  //     </>
-  //   );
-  // }
+        {/* Preview image */}
+        {isImagePreviewOpen && (
+          <WhatsappImagePreviewCMS
+            imageURL="https://tskubmriuclmbcfmaiur.supabase.co/storage/v1/object/public/sevenpreneur/cohort/1765529832399.webp"
+            imageCaption={props.chat.attachment.caption}
+            isOpen={isImagePreviewOpen}
+            onClose={() => setIsImagePreviewOpen(false)}
+          />
+        )}
+      </>
+    );
+  }
 
   return (
     <WhatsappChatBubbleCMS

--- a/src/lib/whatsapp-types.ts
+++ b/src/lib/whatsapp-types.ts
@@ -77,6 +77,7 @@ export type WhatsappAttachmentImage = {
   sha256: string;
   id: string;
   url: string;
+  storage_url?: string;
 };
 
 export type WhatsappAttachmentSticker = {

--- a/src/lib/whatsapp-types.ts
+++ b/src/lib/whatsapp-types.ts
@@ -13,6 +13,7 @@ export type WhatsappAttachmentAudio = {
   id: string;
   url: string;
   voice: boolean;
+  storage_url?: string;
 };
 
 export type WhatsappAttachmentContacts = {
@@ -25,14 +26,14 @@ export type WhatsappAttachmentContacts = {
       street?: string;
       type?: string;
       zip?: string;
-    },
+    }
   ];
   birthday?: string;
   emails?: [
     {
       email?: string;
       type?: string;
-    },
+    }
   ];
   name?: {
     formatted_name?: string;
@@ -52,13 +53,13 @@ export type WhatsappAttachmentContacts = {
       phone?: string;
       wa_id?: string;
       type?: string;
-    },
+    }
   ];
   urls?: [
     {
       url?: string;
       type?: string;
-    },
+    }
   ];
 }[];
 
@@ -69,6 +70,7 @@ export type WhatsappAttachmentDocument = {
   sha256: string;
   id: string;
   url: string;
+  storage_url?: string;
 };
 
 export type WhatsappAttachmentImage = {
@@ -86,6 +88,7 @@ export type WhatsappAttachmentSticker = {
   id: string;
   url: string;
   animated: boolean;
+  storage_url?: string;
 };
 
 export type WhatsappAttachmentVideo = {
@@ -94,6 +97,7 @@ export type WhatsappAttachmentVideo = {
   sha256: string;
   id: string;
   url: string;
+  storage_url?: string;
 };
 
 export type WhatsappAttachmentText = undefined; // will be NULL in database

--- a/src/lib/whatsapp.ts
+++ b/src/lib/whatsapp.ts
@@ -67,3 +67,95 @@ export const whatsappMessageRequest = (
     whatsappReq.end();
   });
 };
+
+export type WhatsappGetMediaURLResponse = {
+  messaging_product: "whatsapp";
+  url: string;
+  mime_type: string;
+  sha256: string;
+  file_size: string;
+  id: string;
+};
+
+// https://developers.facebook.com/documentation/business-messaging/whatsapp/business-phone-numbers/media/?locale=en_US#get-media-url
+export const whatsappGetMediaURLRequest = (
+  mediaID: string
+): Promise<WhatsappGetMediaURLResponse> => {
+  return new Promise((resolve, reject) => {
+    const whatsappRequestOptions: https.RequestOptions = {
+      method: "GET",
+      headers: {
+        Authorization: "Bearer " + process.env.WHATSAPP_ACCESS_TOKEN,
+      },
+    };
+
+    const whatsappPhoneNumberId = process.env.WHATSAPP_PHONE_NUMBER_ID;
+    const whatsappReq = https.request(
+      `https://graph.facebook.com/v23.0/${mediaID}/?phone_number_id=${whatsappPhoneNumberId}`,
+      whatsappRequestOptions,
+      (res) => {
+        let data = "";
+
+        res.on("data", (chunk) => {
+          data += chunk;
+        });
+
+        res.on("end", () => {
+          try {
+            const parsedData = JSON.parse(data);
+            resolve(parsedData);
+          } catch (e) {
+            reject(e);
+          }
+        });
+      }
+    );
+
+    whatsappReq.on("error", (e) => {
+      reject(e);
+    });
+
+    whatsappReq.end();
+  });
+};
+
+// https://developers.facebook.com/documentation/business-messaging/whatsapp/business-phone-numbers/media/?locale=en_US#download-media
+export const whatsappDownloadMediaRequest = (
+  mediaURL: string
+): Promise<Buffer<ArrayBuffer>> => {
+  return new Promise((resolve, reject) => {
+    const whatsappRequestOptions: https.RequestOptions = {
+      method: "GET",
+      headers: {
+        Authorization: "Bearer " + process.env.WHATSAPP_ACCESS_TOKEN,
+      },
+    };
+
+    const whatsappReq = https.request(
+      mediaURL,
+      whatsappRequestOptions,
+      (res) => {
+        const chunks: Uint8Array<ArrayBufferLike>[] = [];
+
+        res.on("data", (chunk) => {
+          chunks.push(chunk);
+        });
+
+        res.on("end", async () => {
+          try {
+            const fileBuffer = Buffer.concat(chunks);
+            resolve(fileBuffer);
+          } catch (e) {
+            reject(e);
+          }
+        });
+      }
+    );
+
+    whatsappReq.on("error", (e) => {
+      reject(e);
+    });
+
+    whatsappReq.end();
+  });
+};


### PR DESCRIPTION
- Tambah field `storage_url` pada tipe `WhatsappAttachmentImage` untuk menyimpan URL publik dari Supabase storage
- Tambah handler `processImageMessage` di file baru `process.wa.webhook.ts` yang menangani pipeline pengambilan dan penyimpanan gambar dari WhatsApp
- Setelah pesan bertipe `image` berhasil disimpan ke DB, webhook route memicu `processImageMessage` secara background (fire-and-forget) untuk menghindari blocking response

## How it works

Ketika webhook menerima pesan gambar dari WhatsApp:

1. **Fetch media URL** — ambil URL sementara dari WhatsApp Graph API menggunakan `media_id`
2. **Download binary** — unduh file gambar dari URL CDN WhatsApp menggunakan Authorization header
3. **Upload ke Supabase storage** — simpan file ke bucket `sevenpreneur` di path `whatsapp/images/`
4. **Get public URL** — ambil URL publik dari Supabase
5. **Update DB** — update field `attachment.storage_url` pada record `WAChat` berdasarkan `wam_id`

Proses ini berjalan secara async (background) sehingga tidak memblokir respons 200 ke WhatsApp dan menghindari retry dari WhatsApp akibat timeout.

## Files changed

- `src/lib/whatsapp-types.ts` — tambah optional field `storage_url` pada `WhatsappAttachmentImage`
- `src/app/(api)/api/whatsapp/webhook/process.wa.webhook.ts` — *(new)* handler untuk proses upload gambar ke Supabase
- `src/app/(api)/api/whatsapp/webhook/route.ts` — trigger `processImageMessage` setelah image message berhasil disimpan
