### PR TITLE
[DB] Enable Supabase Realtime for WhatsApp changes

### DIFF
--- a/docs/db/sevenpreneur-ddl.sql
+++ b/docs/db/sevenpreneur-ddl.sql
@@ -917,6 +917,26 @@ CREATE OR REPLACE FUNCTION wa_get_unread_count(_conv_id CHAR(21))
     )
   );
 
+-- Supabase Realtime
+
+CREATE TYPE wa_broadcast_change_rows AS (id CHAR(21), conv_id CHAR(21));
+
+CREATE OR REPLACE FUNCTION wa_broadcast_changes()
+  RETURNS TRIGGER AS $$
+  BEGIN
+    PERFORM realtime.broadcast_changes(
+      'wa_change',
+      TG_OP,
+      TG_OP,
+      TG_TABLE_NAME,
+      TG_TABLE_SCHEMA,
+      ROW(NEW.id, NEW.conv_id)::wa_broadcast_change_rows,
+      ROW(OLD.id, OLD.conv_id)::wa_broadcast_change_rows
+    );
+    RETURN NULL;
+  END
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
 --------------
 -- Triggers --
 --------------
@@ -1090,6 +1110,13 @@ CREATE TRIGGER update_wa_chats_updated_at_trigger
   FOR EACH ROW
     EXECUTE FUNCTION update_updated_at();
 
+-- Supabase Realtime
+
+CREATE TRIGGER broadcast_wa_changes_trigger
+  AFTER INSERT OR UPDATE OR DELETE ON wa_chats
+  FOR EACH ROW
+    EXECUTE FUNCTION wa_broadcast_changes();
+
 ------------------
 -- Unique Index --
 ------------------
@@ -1117,3 +1144,17 @@ CREATE UNIQUE INDEX interstitial_ads_one_row_only ON interstitial_ads ((TRUE));
 -- Article-related
 
 ALTER SEQUENCE articles_id_seq RESTART WITH 77777;
+
+--------------
+-- Policies --
+--------------
+
+-- Supabase Realtime
+
+CREATE POLICY "Anon users can receive broadcasts for WhatsApp changes"
+  ON realtime.messages
+  FOR SELECT
+  TO public
+  USING (
+    (SELECT realtime.topic()) = 'wa_change'
+  );

--- a/docs/db/sevenpreneur-ddl.sql
+++ b/docs/db/sevenpreneur-ddl.sql
@@ -350,7 +350,7 @@ CREATE TABLE attendances (
   check_in_at   TIMESTAMPTZ      NULL,
   check_out_at  TIMESTAMPTZ      NULL,
   PRIMARY KEY (learning_id, user_id)
-)
+);
 
 -- Business-assessment-related
 

--- a/docs/db/sevenpreneur-dml.sql
+++ b/docs/db/sevenpreneur-dml.sql
@@ -47,17 +47,6 @@ VALUES (
   /* updated_at */ '2025-05-27 09:00:00+07:00'
 );
 
-------------------------
--- Entrepreneur Stage --
-------------------------
-
-INSERT INTO entrepreneur_stages (stage_name, created_at) VALUES
-  ('Ideation',             '2025-05-27 09:00:00+07:00'),
-  ('Feasibility Analysis', '2025-05-27 09:00:00+07:00'),
-  ('Business Planning',    '2025-05-27 09:00:00+07:00'),
-  ('Execution',            '2025-05-27 09:00:00+07:00'),
-  ('Growth',               '2025-05-27 09:00:00+07:00');
-
 ----------------
 -- Industries --
 ----------------


### PR DESCRIPTION
[Subscribing to Database Changes | Supabase Docs](https://supabase.com/docs/guides/realtime/subscribing-to-database-changes)

This trigger will run when there are changes made in `wa_chats` table.

Database changes:

- New type: `wa_broadcast_change_rows`
- New function: `wa_broadcast_changes()`
- New trigger: `broadcast_wa_changes_trigger`
- New policy: `"Anon users can receive broadcasts for WhatsApp changes"`

Related: SVP-264

-------

Example usage:

```javascript
useEffect(() => {
  const changes = supabase
    .channel("wa_change", {
      config: { private: true },
    })
    .on("broadcast", { event: "INSERT" }, (payload) => console.log(payload))
    .on("broadcast", { event: "UPDATE" }, (payload) => console.log(payload))
    .on("broadcast", { event: "DELETE" }, (payload) => console.log(payload))
    .subscribe((status, err) => {
      if (err) {
        console.error("Subscription error:", err);
      } else if (status === "SUBSCRIBED") {
        console.log("Channel subscribed");
      } else if (status === "CHANNEL_ERROR") {
        console.error("Channel encountered an error");
      } else if (status === "TIMED_OUT") {
        console.error("Subscription timed out");
      } else if (status === "CLOSED") {
        console.log("Channel closed");
      }
    });

  return () => {
    supabase.removeChannel(changes);
  };
}, []);
```

-------

Also in this PR,

- Remove unused values
- Fix formatting in database documentation