### PR TITLE
[BE] Send scheduled learning reminders

### DIFF
--- a/src/app/(api)/api/qstash/schedule-learning/route.ts
+++ b/src/app/(api)/api/qstash/schedule-learning/route.ts
@@ -1,0 +1,96 @@
+import { sendEmail } from "@/lib/mailtrap";
+import GetPrismaClient from "@/lib/prisma";
+import GetQStashClient from "@/lib/qstash";
+import {
+  GetUpcomingLearning,
+  LEARNING_REMINDER_SCHEDULE_MINUS_MINUTE,
+  UpdateLearningReminderSchedule,
+} from "@/trpc/utils/schedule_reminder";
+import { NextRequest, NextResponse } from "next/server";
+
+type QStashLearningRemider = {
+  learning_id?: number;
+};
+
+export async function POST(req: NextRequest) {
+  const reqBody: QStashLearningRemider = await req.json();
+  const prisma = GetPrismaClient();
+
+  const upcomingLearning = await GetUpcomingLearning(
+    prisma,
+    LEARNING_REMINDER_SCHEDULE_MINUS_MINUTE + 10
+  );
+  if (!upcomingLearning) {
+    return new NextResponse("OK", {
+      status: 200,
+    });
+  }
+
+  if (upcomingLearning.id !== (reqBody.learning_id || 0)) {
+    const isUpdateScheduleSuccess = await UpdateLearningReminderSchedule(
+      prisma,
+      GetQStashClient()
+    );
+    if (!isUpdateScheduleSuccess) {
+      console.error(
+        "qstash.schedule-learning: Failed to update learning reminder schedule."
+      );
+    }
+
+    return new NextResponse("OK", {
+      status: 200,
+    });
+  }
+
+  const selectedLearning = await prisma.learning.findFirst({
+    select: {
+      cohort_id: true,
+      name: true,
+      meeting_date: true,
+    },
+    where: { id: reqBody.learning_id },
+  });
+  if (!selectedLearning) {
+    console.error(
+      `qstash.schedule-learning: The learning with the given ID (${reqBody.learning_id}) is not found.`
+    );
+
+    return new NextResponse("OK", {
+      status: 200,
+    });
+  }
+
+  const memberList = await prisma.userCohort.findMany({
+    select: {
+      user: {
+        select: {
+          full_name: true,
+          email: true,
+        },
+      },
+    },
+    where: {
+      cohort_id: selectedLearning.cohort_id,
+    },
+  });
+
+  for (const member of memberList) {
+    await sendEmail({
+      mailRecipients: [member.user.email],
+      mailSubject: `Learning Reminder: ${selectedLearning.name}`,
+      mailBody:
+        `Hi, ${member.user.full_name},\n\n` +
+        "We sent you this email to remind you about the upcoming learning session:\n" +
+        `Name: ${selectedLearning.name}\n` +
+        `Date: ${selectedLearning.meeting_date}\n\n` +
+        "More details are posted on Agora LMS.\n\n" +
+        "Intensity gets you started; Consistency keeps you growing. 🚀\n\n" +
+        "Cheers,\n" +
+        "Sevenpreneur Team",
+    });
+  }
+
+  return new NextResponse("OK", {
+    status: 200,
+  });
+}

--- a/src/app/(api)/api/qstash/schedule-learning/route.ts
+++ b/src/app/(api)/api/qstash/schedule-learning/route.ts
@@ -18,7 +18,7 @@ export async function POST(req: NextRequest) {
 
   const upcomingLearning = await GetUpcomingLearning(
     prisma,
-    LEARNING_REMINDER_SCHEDULE_MINUS_MINUTE + 10
+    LEARNING_REMINDER_SCHEDULE_MINUS_MINUTE - 10
   );
   if (!upcomingLearning) {
     return new NextResponse("OK", {

--- a/src/lib/qstash.ts
+++ b/src/lib/qstash.ts
@@ -1,0 +1,7 @@
+import { Client } from "@upstash/qstash";
+
+const qstash = new Client();
+
+export default function GetQStashClient() {
+  return qstash;
+}

--- a/src/trpc/routers/ai_tool/util.ai_tool.ts
+++ b/src/trpc/routers/ai_tool/util.ai_tool.ts
@@ -1,4 +1,5 @@
 import { Optional } from "@/lib/optional-type";
+import GetQStashClient from "@/lib/qstash";
 import { SaveQStashMessageID } from "@/lib/redis";
 import {
   STATUS_FORBIDDEN,
@@ -6,7 +7,6 @@ import {
 } from "@/lib/status_code";
 import { CRoleEnum, PrismaClient } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
-import { Client } from "@upstash/qstash";
 import OpenAI from "openai";
 import { zodTextFormat } from "openai/helpers/zod";
 import { AutoParseableTextFormat } from "openai/lib/parser";
@@ -98,8 +98,6 @@ export function AIFormatOutputZod<T extends z.ZodObject>(
   );
 }
 
-const QStashClient = new Client();
-
 let baseURL = "https://api.sevenpreneur.com/";
 if (process.env.DOMAIN_MODE === "local") {
   baseURL = "https://api.example.com:3000/";
@@ -142,7 +140,9 @@ export async function AIGenerate<T extends AutoParseableTextFormat<U>, U>(
     ];
   }
 
-  const res = await QStashClient.publishJSON({
+  const qstash = GetQStashClient();
+
+  const res = await qstash.publishJSON({
     url: "https://api.openai.com/v1/responses",
     headers: {
       Authorization: `Bearer ${process.env.OPENAI_API_KEY!}`,

--- a/src/trpc/routers/lms/create.lms.ts
+++ b/src/trpc/routers/lms/create.lms.ts
@@ -1,3 +1,4 @@
+import GetQStashClient from "@/lib/qstash";
 import {
   STATUS_CREATED,
   STATUS_FORBIDDEN,
@@ -9,6 +10,7 @@ import {
   roleBasedProcedure,
 } from "@/trpc/init";
 import { readFailedNotFound } from "@/trpc/utils/errors";
+import { UpdateLearningReminderSchedule } from "@/trpc/utils/schedule_reminder";
 import { createSlugFromTitle } from "@/trpc/utils/slug";
 import {
   numberIsID,
@@ -263,6 +265,15 @@ export const createLMS = {
           message: "Failed to create a new learning.",
         });
       }
+
+      const isUpdateScheduleSuccess = await UpdateLearningReminderSchedule(
+        opts.ctx.prisma,
+        GetQStashClient()
+      );
+      if (!isUpdateScheduleSuccess) {
+        console.error("Failed to update learning reminder schedule.");
+      }
+
       return {
         code: STATUS_CREATED,
         message: "Success",

--- a/src/trpc/routers/lms/delete.lms.ts
+++ b/src/trpc/routers/lms/delete.lms.ts
@@ -1,4 +1,5 @@
 import { Optional } from "@/lib/optional-type";
+import GetQStashClient from "@/lib/qstash";
 import { STATUS_FORBIDDEN, STATUS_NO_CONTENT } from "@/lib/status_code";
 import {
   administratorProcedure,
@@ -6,6 +7,7 @@ import {
   roleBasedProcedure,
 } from "@/trpc/init";
 import { checkDeleteResult, readFailedNotFound } from "@/trpc/utils/errors";
+import { UpdateLearningReminderSchedule } from "@/trpc/utils/schedule_reminder";
 import {
   numberIsID,
   objectHasOnlyID,
@@ -96,6 +98,15 @@ export const deleteLMS = {
         },
       });
       checkDeleteResult(deletedLearning.count, "learnings", "learning");
+
+      const isUpdateScheduleSuccess = await UpdateLearningReminderSchedule(
+        opts.ctx.prisma,
+        GetQStashClient()
+      );
+      if (!isUpdateScheduleSuccess) {
+        console.error("Failed to update learning reminder schedule.");
+      }
+
       return {
         code: STATUS_NO_CONTENT,
         message: "Success",

--- a/src/trpc/routers/lms/update.lms.ts
+++ b/src/trpc/routers/lms/update.lms.ts
@@ -1,4 +1,5 @@
 import { Optional } from "@/lib/optional-type";
+import GetQStashClient from "@/lib/qstash";
 import {
   STATUS_BAD_REQUEST,
   STATUS_FORBIDDEN,
@@ -6,6 +7,7 @@ import {
 } from "@/lib/status_code";
 import { loggedInProcedure, roleBasedProcedure } from "@/trpc/init";
 import { checkUpdateResult, readFailedNotFound } from "@/trpc/utils/errors";
+import { UpdateLearningReminderSchedule } from "@/trpc/utils/schedule_reminder";
 import {
   numberIsID,
   stringIsTimestampTz,
@@ -215,6 +217,15 @@ export const updateLMS = {
           },
         });
       checkUpdateResult(updatedLearning.length, "learning", "learnings");
+
+      const isUpdateScheduleSuccess = await UpdateLearningReminderSchedule(
+        opts.ctx.prisma,
+        GetQStashClient()
+      );
+      if (!isUpdateScheduleSuccess) {
+        console.error("Failed to update learning reminder schedule.");
+      }
+
       return {
         code: STATUS_OK,
         message: "Success",

--- a/src/trpc/utils/schedule_reminder.ts
+++ b/src/trpc/utils/schedule_reminder.ts
@@ -18,6 +18,7 @@ export async function GetUpcomingLearning(
       meeting_date: true,
     },
     where: {
+      cohort_id: { lte: 10 },
       meeting_date: { gte: minusXMinutes },
     },
     orderBy: [{ meeting_date: "asc" }],

--- a/src/trpc/utils/schedule_reminder.ts
+++ b/src/trpc/utils/schedule_reminder.ts
@@ -1,0 +1,75 @@
+import GetPrismaClient from "@/lib/prisma";
+import GetQStashClient from "@/lib/qstash";
+
+const LEARNING_REMINDER_SCHEDULE_ID = "sch_learning_reminder";
+
+export const LEARNING_REMINDER_SCHEDULE_MINUS_MINUTE = 30;
+
+export async function GetUpcomingLearning(
+  prisma: ReturnType<typeof GetPrismaClient>,
+  minusMinutes: number
+) {
+  const minusXMinutes = new Date();
+  minusXMinutes.setMinutes(minusXMinutes.getMinutes() - minusMinutes);
+
+  const upcomingLearning = await prisma.learning.findFirst({
+    select: {
+      id: true,
+      meeting_date: true,
+    },
+    where: {
+      meeting_date: { gte: minusXMinutes },
+    },
+    orderBy: [{ meeting_date: "asc" }],
+  });
+  if (!upcomingLearning) {
+    return null;
+  }
+
+  return upcomingLearning;
+}
+
+export async function UpdateLearningReminderSchedule(
+  prisma: ReturnType<typeof GetPrismaClient>,
+  qstash: ReturnType<typeof GetQStashClient>
+) {
+  const upcomingLearning = await GetUpcomingLearning(
+    prisma,
+    LEARNING_REMINDER_SCHEDULE_MINUS_MINUTE
+  );
+  if (!upcomingLearning) {
+    return true;
+  }
+
+  const meetingDate = upcomingLearning.meeting_date;
+  const scheduledTime = new Date(meetingDate.getTime());
+  scheduledTime.setMinutes(
+    meetingDate.getMinutes() - LEARNING_REMINDER_SCHEDULE_MINUS_MINUTE
+  );
+
+  const cronString = [
+    scheduledTime.getUTCMinutes(),
+    scheduledTime.getUTCHours(),
+    scheduledTime.getUTCDate(),
+    scheduledTime.getUTCMonth() + 1, // to be in [1, 12] range
+    "*",
+  ].join(" ");
+
+  const newSchedule = await qstash.schedules.create({
+    scheduleId: LEARNING_REMINDER_SCHEDULE_ID,
+    cron: cronString,
+    destination: "https://api.sevenpreneur.com/qstash/schedule-learning",
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      learning_id: upcomingLearning.id,
+    }),
+  });
+  if (newSchedule.scheduleId !== LEARNING_REMINDER_SCHEDULE_ID) {
+    return false;
+  }
+
+  return true;
+}

--- a/src/trpc/utils/schedule_reminder.ts
+++ b/src/trpc/utils/schedule_reminder.ts
@@ -7,10 +7,10 @@ export const LEARNING_REMINDER_SCHEDULE_MINUS_MINUTE = 30;
 
 export async function GetUpcomingLearning(
   prisma: ReturnType<typeof GetPrismaClient>,
-  minusMinutes: number
+  minusMinutes: number // minutes before meeting date
 ) {
   const minusXMinutes = new Date();
-  minusXMinutes.setMinutes(minusXMinutes.getMinutes() - minusMinutes);
+  minusXMinutes.setMinutes(minusXMinutes.getMinutes() + minusMinutes);
 
   const upcomingLearning = await prisma.learning.findFirst({
     select: {


### PR DESCRIPTION
New endpoint: `/qstash/schedule-learning`

Learning reminders are sent 30 minutes before the session begins. This can be changed by tweaking the `LEARNING_REMINDER_SCHEDULE_MINUS_MINUTE` variable in `src/trpc/utils/schedule_reminder.ts`.

Related: SVP-273

Also in this PR,
- Factor out QStash client object creation