### PR TITLE
[BE] Improve learning reminder

### DIFF
--- a/src/app/(api)/api/qstash/schedule-learning/route.ts
+++ b/src/app/(api)/api/qstash/schedule-learning/route.ts
@@ -27,6 +27,24 @@ type QStashLearningRemider = {
   learning_id?: number;
 };
 
+async function updateScheduleAndReturn(
+  prisma: ReturnType<typeof GetPrismaClient>
+) {
+  const isUpdateScheduleSuccess = await UpdateLearningReminderSchedule(
+    prisma,
+    GetQStashClient()
+  );
+  if (!isUpdateScheduleSuccess) {
+    console.error(
+      "qstash.schedule-learning: Failed to update learning reminder schedule."
+    );
+  }
+
+  return new NextResponse("OK", {
+    status: 200,
+  });
+}
+
 export async function POST(req: NextRequest) {
   const reqBody: QStashLearningRemider = await req.json();
   const prisma = GetPrismaClient();
@@ -36,21 +54,11 @@ export async function POST(req: NextRequest) {
     LEARNING_REMINDER_SCHEDULE_MINUS_MINUTE - 10
   );
   if (!upcomingLearning) {
-    return new NextResponse("OK", { status: 200 });
+    return await updateScheduleAndReturn(prisma);
   }
 
   if (upcomingLearning.id !== (reqBody.learning_id || 0)) {
-    const isUpdateScheduleSuccess = await UpdateLearningReminderSchedule(
-      prisma,
-      GetQStashClient()
-    );
-    if (!isUpdateScheduleSuccess) {
-      console.error(
-        "qstash.schedule-learning: Failed to update learning reminder schedule."
-      );
-    }
-
-    return new NextResponse("OK", { status: 200 });
+    return await updateScheduleAndReturn(prisma);
   }
 
   const selectedLearning = await prisma.learning.findFirst({
@@ -76,7 +84,7 @@ export async function POST(req: NextRequest) {
       `qstash.schedule-learning: The learning with the given ID (${reqBody.learning_id}) is not found.`
     );
 
-    return new NextResponse("OK", { status: 200 });
+    return await updateScheduleAndReturn(prisma);
   }
 
   const sessionDate = dayjs(selectedLearning.meeting_date)

--- a/src/app/(api)/api/qstash/schedule-learning/route.ts
+++ b/src/app/(api)/api/qstash/schedule-learning/route.ts
@@ -49,7 +49,7 @@ export async function POST() {
 
   const upcomingLearning = await GetUpcomingLearning(
     prisma,
-    LEARNING_REMINDER_SCHEDULE_MINUS_MINUTE - 10
+    LEARNING_REMINDER_SCHEDULE_MINUS_MINUTE - 5
   );
   if (!upcomingLearning) {
     return await updateScheduleAndReturn(prisma);

--- a/src/app/(api)/api/qstash/schedule-learning/route.ts
+++ b/src/app/(api)/api/qstash/schedule-learning/route.ts
@@ -3,6 +3,7 @@ import { sendEmail } from "@/lib/mailtrap";
 import GetPrismaClient from "@/lib/prisma";
 import GetQStashClient from "@/lib/qstash";
 import {
+  GetNearbyLearnings,
   GetUpcomingLearning,
   LEARNING_REMINDER_SCHEDULE_MINUS_MINUTE,
   UpdateLearningReminderSchedule,
@@ -16,23 +17,21 @@ import dayjs from "dayjs";
 import "dayjs/locale/id";
 import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { createElement } from "react";
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
 dayjs.locale("id");
 
-type QStashLearningRemider = {
-  learning_id?: number;
-};
-
 async function updateScheduleAndReturn(
-  prisma: ReturnType<typeof GetPrismaClient>
+  prisma: ReturnType<typeof GetPrismaClient>,
+  exclusionList?: number[] // learning IDs to be excluded
 ) {
   const isUpdateScheduleSuccess = await UpdateLearningReminderSchedule(
     prisma,
-    GetQStashClient()
+    GetQStashClient(),
+    exclusionList
   );
   if (!isUpdateScheduleSuccess) {
     console.error(
@@ -45,8 +44,7 @@ async function updateScheduleAndReturn(
   });
 }
 
-export async function POST(req: NextRequest) {
-  const reqBody: QStashLearningRemider = await req.json();
+export async function POST() {
   const prisma = GetPrismaClient();
 
   const upcomingLearning = await GetUpcomingLearning(
@@ -57,91 +55,71 @@ export async function POST(req: NextRequest) {
     return await updateScheduleAndReturn(prisma);
   }
 
-  if (upcomingLearning.id !== (reqBody.learning_id || 0)) {
-    return await updateScheduleAndReturn(prisma);
-  }
+  const selectedLearnings = await GetNearbyLearnings(
+    prisma,
+    upcomingLearning.meeting_date
+  );
 
-  const selectedLearning = await prisma.learning.findFirst({
-    select: {
-      cohort_id: true,
-      name: true,
-      meeting_date: true,
-      method: true,
-      meeting_url: true,
-      location_name: true,
-      location_url: true,
-      cohort: {
-        select: {
-          name: true,
-          image: true,
+  for (const learning of selectedLearnings) {
+    const sessionDate = dayjs(learning.meeting_date)
+      .tz("Asia/Jakarta")
+      .format("dddd, D MMMM YYYY - HH:mm [WIB]");
+
+    const conferenceName = learning.meeting_url
+      ? getConferenceAttributes(
+          getConferenceVariantFromURL(learning.meeting_url)
+        ).conferenceName
+      : "Online";
+
+    let sessionPlace = conferenceName;
+    if (learning.method === "ONSITE") {
+      sessionPlace = learning.location_name ?? "Onsite";
+    } else if (learning.method === "HYBRID") {
+      sessionPlace = `${learning.location_name ?? "Onsite"} (Hybrid via ${conferenceName})`;
+    }
+
+    const memberList = await prisma.userCohort.findMany({
+      select: {
+        user: {
+          select: {
+            full_name: true,
+            email: true,
+          },
         },
       },
-    },
-    where: { id: reqBody.learning_id },
-  });
-  if (!selectedLearning) {
-    console.error(
-      `qstash.schedule-learning: The learning with the given ID (${reqBody.learning_id}) is not found.`
-    );
-
-    return await updateScheduleAndReturn(prisma);
-  }
-
-  const sessionDate = dayjs(selectedLearning.meeting_date)
-    .tz("Asia/Jakarta")
-    .format("dddd, D MMMM YYYY - HH:mm [WIB]");
-
-  const conferenceName = selectedLearning.meeting_url
-    ? getConferenceAttributes(
-        getConferenceVariantFromURL(selectedLearning.meeting_url)
-      ).conferenceName
-    : "Online";
-
-  let sessionPlace = conferenceName;
-  if (selectedLearning.method === "ONSITE") {
-    sessionPlace = selectedLearning.location_name ?? "Onsite";
-  } else if (selectedLearning.method === "HYBRID") {
-    sessionPlace = `${selectedLearning.location_name ?? "Onsite"} (Hybrid via ${conferenceName})`;
-  }
-
-  const memberList = await prisma.userCohort.findMany({
-    select: {
-      user: {
-        select: {
-          full_name: true,
-          email: true,
-        },
+      where: {
+        cohort_id: learning.cohort_id,
       },
-    },
-    where: {
-      cohort_id: selectedLearning.cohort_id,
-    },
-  });
-
-  for (const member of memberList) {
-    const firstName = member.user.full_name.split(" ")[0];
-
-    const html = await render(
-      createElement(SessionReminderEmail, {
-        firstName,
-        cohortName: selectedLearning.cohort.name,
-        cohortImage: selectedLearning.cohort.image,
-        sessionName: selectedLearning.name,
-        sessionPlace,
-        sessionDate,
-        joinUrl:
-          selectedLearning.method === "ONSITE"
-            ? (selectedLearning.location_url ?? undefined)
-            : (selectedLearning.meeting_url ?? undefined),
-      })
-    );
-
-    await sendEmail({
-      mailRecipients: [member.user.email],
-      mailSubject: `Mulai Sebentar Lagi! ${selectedLearning.name} by MIFX`,
-      mailHtml: html,
     });
+
+    for (const member of memberList) {
+      const firstName = member.user.full_name.split(" ")[0];
+
+      const html = await render(
+        createElement(SessionReminderEmail, {
+          firstName,
+          cohortName: learning.cohort.name,
+          cohortImage: learning.cohort.image,
+          sessionName: learning.name,
+          sessionPlace,
+          sessionDate,
+          joinUrl:
+            learning.method === "ONSITE"
+              ? (learning.location_url ?? undefined)
+              : (learning.meeting_url ?? undefined),
+        })
+      );
+
+      await sendEmail({
+        mailRecipients: [member.user.email],
+        mailSubject: `Mulai Sebentar Lagi! ${learning.name} by MIFX`,
+        mailHtml: html,
+      });
+    }
   }
 
-  return await updateScheduleAndReturn(prisma);
+  return await updateScheduleAndReturn(
+    prisma,
+    selectedLearnings.map((entry) => entry.id)
+  );
 }

--- a/src/app/(api)/api/qstash/schedule-learning/route.ts
+++ b/src/app/(api)/api/qstash/schedule-learning/route.ts
@@ -143,5 +143,5 @@ export async function POST(req: NextRequest) {
     });
   }
 
-  return new NextResponse("OK", { status: 200 });
+  return await updateScheduleAndReturn(prisma);
 }

--- a/src/trpc/utils/schedule_reminder.ts
+++ b/src/trpc/utils/schedule_reminder.ts
@@ -9,7 +9,8 @@ export const LEARNING_REMINDER_SCHEDULE_MINUS_MINUTE = 30;
 
 export async function GetUpcomingLearning(
   prisma: ReturnType<typeof GetPrismaClient>,
-  minusMinutes: number // minutes before meeting date
+  minusMinutes: number, // minutes before meeting date
+  exclusionList?: number[] // learning IDs to be excluded
 ) {
   const minusXMinutes = new Date();
   minusXMinutes.setMinutes(minusXMinutes.getMinutes() + minusMinutes);
@@ -20,6 +21,7 @@ export async function GetUpcomingLearning(
       meeting_date: true,
     },
     where: {
+      id: { notIn: exclusionList },
       meeting_date: { gt: minusXMinutes },
     },
     orderBy: [{ meeting_date: "asc" }],
@@ -31,13 +33,53 @@ export async function GetUpcomingLearning(
   return upcomingLearning;
 }
 
+export async function GetNearbyLearnings(
+  prisma: ReturnType<typeof GetPrismaClient>,
+  meetingDate: Date
+) {
+  const searchDate = new Date(meetingDate.getTime());
+  searchDate.setMinutes(
+    searchDate.getMinutes() + SCHEDULE_MINIMUM_MINUTE_FROM_NOW
+  );
+
+  const upcomingLearnings = await prisma.learning.findMany({
+    select: {
+      id: true,
+      cohort_id: true,
+      name: true,
+      meeting_date: true,
+      method: true,
+      meeting_url: true,
+      location_name: true,
+      location_url: true,
+      cohort: {
+        select: {
+          name: true,
+          image: true,
+        },
+      },
+    },
+    where: {
+      meeting_date: {
+        gte: meetingDate,
+        lte: searchDate,
+      },
+    },
+    orderBy: [{ meeting_date: "asc" }],
+  });
+
+  return upcomingLearnings;
+}
+
 export async function UpdateLearningReminderSchedule(
   prisma: ReturnType<typeof GetPrismaClient>,
-  qstash: ReturnType<typeof GetQStashClient>
+  qstash: ReturnType<typeof GetQStashClient>,
+  exclusionList?: number[] // learning IDs to be excluded
 ) {
   const upcomingLearning = await GetUpcomingLearning(
     prisma,
-    LEARNING_REMINDER_SCHEDULE_MINUS_MINUTE
+    LEARNING_REMINDER_SCHEDULE_MINUS_MINUTE,
+    exclusionList
   );
   if (!upcomingLearning) {
     // Delete schedule if there is no upcoming learning.
@@ -74,12 +116,8 @@ export async function UpdateLearningReminderSchedule(
     cron: cronString,
     destination: "https://api.sevenpreneur.com/qstash/schedule-learning",
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      learning_id: upcomingLearning.id,
-    }),
+    headers: { "Content-Type": "application/json" },
+    body: "{}",
   });
   if (newSchedule.scheduleId !== LEARNING_REMINDER_SCHEDULE_ID) {
     return false;

--- a/src/trpc/utils/schedule_reminder.ts
+++ b/src/trpc/utils/schedule_reminder.ts
@@ -3,6 +3,8 @@ import GetQStashClient from "@/lib/qstash";
 
 const LEARNING_REMINDER_SCHEDULE_ID = "sch_learning_reminder";
 
+const SCHEDULE_MINIMUM_MINUTE_FROM_NOW = 2;
+
 export const LEARNING_REMINDER_SCHEDULE_MINUS_MINUTE = 30;
 
 export async function GetUpcomingLearning(
@@ -43,10 +45,20 @@ export async function UpdateLearningReminderSchedule(
     return true;
   }
 
+  const minimumTime = new Date();
+  minimumTime.setMinutes(
+    minimumTime.getMinutes() + SCHEDULE_MINIMUM_MINUTE_FROM_NOW
+  );
+
   const meetingDate = upcomingLearning.meeting_date;
   const scheduledTime = new Date(meetingDate.getTime());
   scheduledTime.setMinutes(
     meetingDate.getMinutes() - LEARNING_REMINDER_SCHEDULE_MINUS_MINUTE
+  );
+
+  // Minimum time to schedule a reminder to avoid "in a year" schedule
+  scheduledTime.setTime(
+    Math.max(minimumTime.getTime(), scheduledTime.getTime())
   );
 
   const cronString = [

--- a/src/trpc/utils/schedule_reminder.ts
+++ b/src/trpc/utils/schedule_reminder.ts
@@ -20,7 +20,7 @@ export async function GetUpcomingLearning(
       meeting_date: true,
     },
     where: {
-      meeting_date: { gte: minusXMinutes },
+      meeting_date: { gt: minusXMinutes },
     },
     orderBy: [{ meeting_date: "asc" }],
   });

--- a/src/trpc/utils/schedule_reminder.ts
+++ b/src/trpc/utils/schedule_reminder.ts
@@ -38,6 +38,8 @@ export async function UpdateLearningReminderSchedule(
     LEARNING_REMINDER_SCHEDULE_MINUS_MINUTE
   );
   if (!upcomingLearning) {
+    // Delete schedule if there is no upcoming learning.
+    await qstash.schedules.delete(LEARNING_REMINDER_SCHEDULE_ID);
     return true;
   }
 


### PR DESCRIPTION
- Delete schedule if there is no upcoming learning
- Add minimum time to schedule a reminder. This is done to avoid "in a year" schedule.
- Factor out update schedule in webhook
- Use `>` instead of `>=` when getting upcoming learning
- Update schedule after sending reminder successfully
- Support reminding multiple learnings with the same time
- Make offset smaller when getting upcoming learning