### PR TITLE
[BE] Support resuming sending learning reminders

### DIFF
--- a/src/app/(api)/api/qstash/schedule-learning/route.ts
+++ b/src/app/(api)/api/qstash/schedule-learning/route.ts
@@ -90,6 +90,7 @@ export const POST = verifySignatureAppRouter(async () => {
       where: {
         cohort_id: learning.cohort_id,
       },
+      orderBy: [{ user: { created_at: "asc" } }, { user: { id: "asc" } }],
     });
 
     for (const member of memberList) {

--- a/src/app/(api)/api/qstash/schedule-learning/route.ts
+++ b/src/app/(api)/api/qstash/schedule-learning/route.ts
@@ -13,11 +13,11 @@ import {
   getConferenceVariantFromURL,
 } from "@/lib/conference-variant";
 import { render } from "@react-email/render";
+import { verifySignatureAppRouter } from "@upstash/qstash/dist/nextjs";
 import dayjs from "dayjs";
 import "dayjs/locale/id";
 import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
-import { NextResponse } from "next/server";
 import { createElement } from "react";
 
 dayjs.extend(utc);
@@ -39,12 +39,12 @@ async function updateScheduleAndReturn(
     );
   }
 
-  return new NextResponse("OK", {
-    status: 200,
+  return Response.json({
+    received: true, // Tell QStash that the result has been received successfully
   });
 }
 
-export async function POST() {
+export const POST = verifySignatureAppRouter(async () => {
   const prisma = GetPrismaClient();
 
   const upcomingLearning = await GetUpcomingLearning(
@@ -122,4 +122,4 @@ export async function POST() {
     prisma,
     selectedLearnings.map((entry) => entry.id)
   );
-}
+});

--- a/src/app/(api)/api/qstash/schedule-learning/route.ts
+++ b/src/app/(api)/api/qstash/schedule-learning/route.ts
@@ -3,6 +3,7 @@ import { sendEmail } from "@/lib/mailtrap";
 import GetPrismaClient from "@/lib/prisma";
 import GetQStashClient from "@/lib/qstash";
 import {
+  GetLearnings,
   GetNearbyLearnings,
   GetUpcomingLearning,
   LEARNING_REMINDER_SCHEDULE_MINUS_MINUTE,
@@ -19,18 +20,26 @@ import "dayjs/locale/id";
 import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
 import { createElement } from "react";
+import { NextRequest } from "next/server";
+
+const SEND_REMINDER_MAX_DURATION = 40 * 1000; // 40 seconds
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
 dayjs.locale("id");
 
+type QStashLearningReminder = {
+  progress?: Record<number, number>;
+};
+
 async function updateScheduleAndReturn(
   prisma: ReturnType<typeof GetPrismaClient>,
+  qstash: ReturnType<typeof GetQStashClient>,
   exclusionList?: number[] // learning IDs to be excluded
 ) {
   const isUpdateScheduleSuccess = await UpdateLearningReminderSchedule(
     prisma,
-    GetQStashClient(),
+    qstash,
     exclusionList
   );
   if (!isUpdateScheduleSuccess) {
@@ -44,21 +53,40 @@ async function updateScheduleAndReturn(
   });
 }
 
-export const POST = verifySignatureAppRouter(async () => {
+export const POST = verifySignatureAppRouter(async (req: NextRequest) => {
+  const startTime = Date.now();
+
+  const reqBody: QStashLearningReminder = await req.json();
+
   const prisma = GetPrismaClient();
+  const qstash = GetQStashClient();
 
-  const upcomingLearning = await GetUpcomingLearning(
-    prisma,
-    LEARNING_REMINDER_SCHEDULE_MINUS_MINUTE - 5
-  );
-  if (!upcomingLearning) {
-    return await updateScheduleAndReturn(prisma);
+  let currentProgress = {} as Record<number, number>;
+  let selectedLearnings = [] as Awaited<ReturnType<typeof GetLearnings>>;
+  if (reqBody.progress) {
+    currentProgress = reqBody.progress;
+    selectedLearnings = await GetLearnings(
+      prisma,
+      Object.keys(reqBody.progress).map((entry) => Number(entry))
+    );
+  } else {
+    const upcomingLearning = await GetUpcomingLearning(
+      prisma,
+      LEARNING_REMINDER_SCHEDULE_MINUS_MINUTE - 5
+    );
+    if (!upcomingLearning) {
+      return await updateScheduleAndReturn(prisma, qstash);
+    }
+
+    selectedLearnings = await GetNearbyLearnings(
+      prisma,
+      upcomingLearning.meeting_date
+    );
+
+    for (const learning of selectedLearnings) {
+      currentProgress[learning.id] = -1; // None (before index 0)
+    }
   }
-
-  const selectedLearnings = await GetNearbyLearnings(
-    prisma,
-    upcomingLearning.meeting_date
-  );
 
   for (const learning of selectedLearnings) {
     const sessionDate = dayjs(learning.meeting_date)
@@ -93,7 +121,10 @@ export const POST = verifySignatureAppRouter(async () => {
       orderBy: [{ user: { created_at: "asc" } }, { user: { id: "asc" } }],
     });
 
-    for (const member of memberList) {
+    // +1 to get the next index
+    for (let i = currentProgress[learning.id] + 1; i < memberList.length; i++) {
+      const member = memberList[i];
+
       const firstName = member.user.full_name.split(" ")[0];
 
       const html = await render(
@@ -116,11 +147,29 @@ export const POST = verifySignatureAppRouter(async () => {
         mailSubject: `Mulai Sebentar Lagi! ${learning.name} by MIFX`,
         mailHtml: html,
       });
+
+      currentProgress[learning.id] = i;
+
+      // Queue another batch if already running for more than max duration
+      const duration = Date.now() - startTime;
+      if (duration >= SEND_REMINDER_MAX_DURATION) {
+        await qstash.publishJSON({
+          url: "https://api.sevenpreneur.com/qstash/schedule-learning",
+          body: {
+            progress: currentProgress,
+          },
+        });
+
+        return Response.json({
+          received: true,
+        });
+      }
     }
   }
 
   return await updateScheduleAndReturn(
     prisma,
+    qstash,
     selectedLearnings.map((entry) => entry.id)
   );
 });

--- a/src/app/(api)/api/qstash/schedule-learning/route.ts
+++ b/src/app/(api)/api/qstash/schedule-learning/route.ts
@@ -1,4 +1,8 @@
 import { SessionReminderEmail } from "@/components/emails/SessionReminderEmail";
+import {
+  getConferenceAttributes,
+  getConferenceVariantFromURL,
+} from "@/lib/conference-variant";
 import { sendEmail } from "@/lib/mailtrap";
 import GetPrismaClient from "@/lib/prisma";
 import GetQStashClient from "@/lib/qstash";
@@ -9,18 +13,14 @@ import {
   LEARNING_REMINDER_SCHEDULE_MINUS_MINUTE,
   UpdateLearningReminderSchedule,
 } from "@/trpc/utils/schedule_reminder";
-import {
-  getConferenceAttributes,
-  getConferenceVariantFromURL,
-} from "@/lib/conference-variant";
 import { render } from "@react-email/render";
 import { verifySignatureAppRouter } from "@upstash/qstash/dist/nextjs";
 import dayjs from "dayjs";
 import "dayjs/locale/id";
 import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
-import { createElement } from "react";
 import { NextRequest } from "next/server";
+import { createElement } from "react";
 
 const SEND_REMINDER_MAX_DURATION = 40 * 1000; // 40 seconds
 

--- a/src/app/(api)/api/qstash/schedule-learning/route.ts
+++ b/src/app/(api)/api/qstash/schedule-learning/route.ts
@@ -19,7 +19,6 @@ import dayjs from "dayjs";
 import "dayjs/locale/id";
 import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
-import { NextRequest } from "next/server";
 import { createElement } from "react";
 
 const SEND_REMINDER_MAX_DURATION = 40 * 1000; // 40 seconds
@@ -53,7 +52,7 @@ async function updateScheduleAndReturn(
   });
 }
 
-export const POST = verifySignatureAppRouter(async (req: NextRequest) => {
+export const POST = verifySignatureAppRouter(async (req: Request) => {
   const startTime = Date.now();
 
   const reqBody: QStashLearningReminder = await req.json();

--- a/src/trpc/utils/schedule_reminder.ts
+++ b/src/trpc/utils/schedule_reminder.ts
@@ -33,16 +33,11 @@ export async function GetUpcomingLearning(
   return upcomingLearning;
 }
 
-export async function GetNearbyLearnings(
+export async function GetLearnings(
   prisma: ReturnType<typeof GetPrismaClient>,
-  meetingDate: Date
+  idList: number[]
 ) {
-  const searchDate = new Date(meetingDate.getTime());
-  searchDate.setMinutes(
-    searchDate.getMinutes() + SCHEDULE_MINIMUM_MINUTE_FROM_NOW
-  );
-
-  const upcomingLearnings = await prisma.learning.findMany({
+  const learningList = await prisma.learning.findMany({
     select: {
       id: true,
       cohort_id: true,
@@ -60,6 +55,26 @@ export async function GetNearbyLearnings(
       },
     },
     where: {
+      id: { in: idList },
+    },
+    orderBy: [{ meeting_date: "asc" }, { id: "asc" }],
+  });
+
+  return learningList;
+}
+
+export async function GetNearbyLearnings(
+  prisma: ReturnType<typeof GetPrismaClient>,
+  meetingDate: Date
+) {
+  const searchDate = new Date(meetingDate.getTime());
+  searchDate.setMinutes(
+    searchDate.getMinutes() + SCHEDULE_MINIMUM_MINUTE_FROM_NOW
+  );
+
+  const upcomingLearningList = await prisma.learning.findMany({
+    select: { id: true },
+    where: {
       meeting_date: {
         gte: meetingDate,
         lte: searchDate,
@@ -67,6 +82,10 @@ export async function GetNearbyLearnings(
     },
     orderBy: [{ meeting_date: "asc" }, { id: "asc" }],
   });
+
+  const upcomingLearningIDs = upcomingLearningList.map((entry) => entry.id);
+
+  const upcomingLearnings = await GetLearnings(prisma, upcomingLearningIDs);
 
   return upcomingLearnings;
 }

--- a/src/trpc/utils/schedule_reminder.ts
+++ b/src/trpc/utils/schedule_reminder.ts
@@ -24,7 +24,7 @@ export async function GetUpcomingLearning(
       id: { notIn: exclusionList },
       meeting_date: { gt: minusXMinutes },
     },
-    orderBy: [{ meeting_date: "asc" }],
+    orderBy: [{ meeting_date: "asc" }, { id: "asc" }],
   });
   if (!upcomingLearning) {
     return null;
@@ -65,7 +65,7 @@ export async function GetNearbyLearnings(
         lte: searchDate,
       },
     },
-    orderBy: [{ meeting_date: "asc" }],
+    orderBy: [{ meeting_date: "asc" }, { id: "asc" }],
   });
 
   return upcomingLearnings;

--- a/src/trpc/utils/schedule_reminder.ts
+++ b/src/trpc/utils/schedule_reminder.ts
@@ -1,5 +1,6 @@
 import GetPrismaClient from "@/lib/prisma";
 import GetQStashClient from "@/lib/qstash";
+import { StatusEnum } from "@prisma/client";
 
 const LEARNING_REMINDER_SCHEDULE_ID = "sch_learning_reminder";
 
@@ -23,6 +24,7 @@ export async function GetUpcomingLearning(
     where: {
       id: { notIn: exclusionList },
       meeting_date: { gt: minusXMinutes },
+      status: StatusEnum.ACTIVE,
     },
     orderBy: [{ meeting_date: "asc" }, { id: "asc" }],
   });
@@ -79,6 +81,7 @@ export async function GetNearbyLearnings(
         gte: meetingDate,
         lte: searchDate,
       },
+      status: StatusEnum.ACTIVE,
     },
     orderBy: [{ meeting_date: "asc" }, { id: "asc" }],
   });


### PR DESCRIPTION
Support resuming after execution time limit using QStash queues. The maximum duration is set to 40 seconds. (Vercel's maximum duration is 60 seconds.) Learning and member list order are made as fixed as possible to ensure continuity.

Also in this PR,
- Use `verifySignatureAppRouter` for QStash webhook
- Organize imports